### PR TITLE
Change fields to correctly reflect, that we return the installs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -104,7 +104,7 @@ def get_category(
 
     ids = apps.get_category(category)
 
-    sorted_ids = sort_ids_by_downloads(ids)
+    sorted_ids = sort_ids_by_installs(ids)
 
     if page is None:
         return sorted_ids
@@ -128,7 +128,7 @@ def get_developer(
         response.status_code = 404
         return response
 
-    sorted_ids = sort_ids_by_downloads(ids)
+    sorted_ids = sort_ids_by_installs(ids)
 
     return sorted_ids
 
@@ -205,7 +205,7 @@ def get_stats(response: Response):
 
 @app.get("/stats/{appid}", status_code=200)
 def get_stats_for_app(appid: str, response: Response):
-    if value := stats.get_downloads_by_ids([appid]).get(appid, None):
+    if value := stats.get_installs_by_ids([appid]).get(appid, None):
         return value
 
     response.status_code = 404
@@ -283,15 +283,15 @@ def get_download_token(appids: List[str], login=Depends(logins.login_state)):
     }
 
 
-def sort_ids_by_downloads(ids):
+def sort_ids_by_installs(ids):
     if len(ids) <= 1:
         return ids
 
-    downloads = stats.get_downloads_by_ids(ids)
+    installs = stats.get_installs_by_ids(ids)
     sorted_ids = sorted(
         ids,
-        key=lambda appid: downloads.get(appid, {"downloads_last_month": 0}).get(
-            "downloads_last_month", 0
+        key=lambda appid: installs.get(appid, {"installs_last_month": 0}).get(
+            "installs_last_month", 0
         ),
         reverse=True,
     )

--- a/backend/app/stats.py
+++ b/backend/app/stats.py
@@ -158,7 +158,7 @@ def _is_app(app_id: str) -> bool:
     return "/" not in app_id
 
 
-def get_downloads_by_ids(ids: List[str]):
+def get_installs_by_ids(ids: List[str]):
     result = defaultdict()
     for app_id in ids:
         if not _is_app(app_id):
@@ -210,31 +210,31 @@ def update(all_app_ids: list):
         if _is_app(appid):
             # Index 0 is install and update count index 1 would be the update count
             # Index 2 is the install count
-            stats_apps_dict[appid]["downloads_total"] = sum(
+            stats_apps_dict[appid]["installs_total"] = sum(
                 [i[2] for i in dict.values()]
             )
 
             if appid in app_stats_per_day:
-                stats_apps_dict[appid]["downloads_per_day"] = app_stats_per_day[appid]
+                stats_apps_dict[appid]["installs_per_day"] = app_stats_per_day[appid]
 
     sdate_30_days = edate - datetime.timedelta(days=30 - 1)
     stats_30_days = _get_stats_for_period(sdate_30_days, edate)
 
-    stats_downloads: List = []
+    stats_installs: List = []
     for appid, dict in stats_30_days.items():
         if _is_app(appid):
             # Index 0 is install and update count index 1 would be the update count
             # Index 2 is the install count
-            downloads_last_month = sum([i[2] for i in dict.values()])
-            stats_apps_dict[appid]["downloads_last_month"] = downloads_last_month
+            installs_last_month = sum([i[2] for i in dict.values()])
+            stats_apps_dict[appid]["installs_last_month"] = installs_last_month
             if appid in all_app_ids:
-                stats_downloads.append(
+                stats_installs.append(
                     {
                         "id": utils.get_clean_app_id(appid),
-                        "downloads_last_month": downloads_last_month,
+                        "installs_last_month": installs_last_month,
                     }
                 )
-    search.update_apps(stats_downloads)
+    search.update_apps(stats_installs)
 
     sdate_7_days = edate - datetime.timedelta(days=7 - 1)
     stats_7_days = _get_stats_for_period(sdate_7_days, edate)
@@ -243,7 +243,7 @@ def update(all_app_ids: list):
         if _is_app(appid):
             # Index 0 is install and update count index 1 would be the update count
             # Index 2 is the install count
-            stats_apps_dict[appid]["downloads_last_7_days"] = sum(
+            stats_apps_dict[appid]["installs_last_7_days"] = sum(
                 [i[2] for i in dict.values()]
             )
 

--- a/backend/tests/main.py
+++ b/backend/tests/main.py
@@ -310,10 +310,10 @@ def test_app_stats_by_id(client):
     today = datetime.date.today()
     day_before_yesterday = today - datetime.timedelta(days=2)
     expected = {
-        "downloads_total": 7,
-        "downloads_per_day": {day_before_yesterday.isoformat(): 6},
-        "downloads_last_month": 7,
-        "downloads_last_7_days": 7,
+        "installs_total": 7,
+        "installs_per_day": {day_before_yesterday.isoformat(): 6},
+        "installs_last_month": 7,
+        "installs_last_7_days": 7,
     }
 
     assert response.status_code == 200

--- a/frontend/src/components/application/AdditionalInfo.tsx
+++ b/frontend/src/components/application/AdditionalInfo.tsx
@@ -89,10 +89,10 @@ const AdditionalInfo = ({
         items={[
           {
             icon: <MdCloudDownload />,
-            header: t("downloads"),
+            header: t("installs"),
             content: {
               type: "text",
-              text: stats.downloads_total.toLocaleString(
+              text: stats.installs_total.toLocaleString(
                 i18n.language.substring(0, 2),
               ),
             },

--- a/frontend/src/components/application/AppStats.module.scss
+++ b/frontend/src/components/application/AppStats.module.scss
@@ -1,4 +1,4 @@
-.downloads {
+.installs {
   height: 300px;
   padding-top: 16px;
   padding-bottom: 48px;

--- a/frontend/src/components/application/AppStats.tsx
+++ b/frontend/src/components/application/AppStats.tsx
@@ -16,29 +16,29 @@ interface Props {
 const AppStatistics: FunctionComponent<Props> = ({ stats }) => {
   const { t } = useTranslation()
   const { resolvedTheme } = useTheme()
-  let downloads_labels: Date[] = []
-  let downloads_data: number[] = []
-  if (stats.downloads_per_day) {
-    for (const [key, value] of Object.entries(stats.downloads_per_day)) {
-      downloads_labels.push(new Date(key))
-      downloads_data.push(value)
+  let installs_labels: Date[] = []
+  let installs_data: number[] = []
+  if (stats.installs_per_day) {
+    for (const [key, value] of Object.entries(stats.installs_per_day)) {
+      installs_labels.push(new Date(key))
+      installs_data.push(value)
     }
   }
 
   // Remove current day
-  downloads_labels.pop()
-  downloads_data.pop()
+  installs_labels.pop()
+  installs_data.pop()
 
   const data = chartStyle(
-    downloads_labels,
-    downloads_data,
+    installs_labels,
+    installs_data,
     t("installs"),
     resolvedTheme,
   )
   const options = chartOptions(i18n.language)
 
   return (
-    <div className={styles.downloads}>
+    <div className={styles.installs}>
       <h3>{t("installs-over-time")}</h3>
       <Line data={data} options={options} />
     </div>

--- a/frontend/src/components/application/Releases.tsx
+++ b/frontend/src/components/application/Releases.tsx
@@ -1,12 +1,6 @@
 import { formatDistance } from "date-fns"
 import { useTranslation } from "next-i18next"
-import {
-  FunctionComponent,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import { FunctionComponent, useEffect, useMemo, useRef, useState } from "react"
 import { getLocale } from "../../localize"
 
 import { Release } from "../../types/Appstream"
@@ -22,7 +16,7 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
   const [scrollHeight, setScrollHeight] = useState(0)
   const ref = useRef(null)
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     setScrollHeight(ref.current.scrollHeight)
   }, [ref])
 

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -78,10 +78,10 @@ export async function fetchAppStats(appId: string): Promise<AppStats> {
   if (!statsJson) {
     console.log("No stats data for ", appId)
     statsJson = {
-      downloads_per_day: {},
-      downloads_last_7_days: 0,
-      downloads_last_month: 0,
-      downloads_total: 0,
+      installs_per_day: {},
+      installs_last_7_days: 0,
+      installs_last_month: 0,
+      installs_total: 0,
     }
   }
   return statsJson

--- a/frontend/src/types/AppStats.ts
+++ b/frontend/src/types/AppStats.ts
@@ -1,6 +1,6 @@
 export interface AppStats {
-  downloads_last_month: number
-  downloads_total: number
-  downloads_last_7_days: number
-  downloads_per_day: { [key: string]: number }
+  installs_last_month: number
+  installs_total: number
+  installs_last_7_days: number
+  installs_per_day: { [key: string]: number }
 }


### PR DESCRIPTION
New repo version of https://github.com/flathub/backend/pull/165 and https://github.com/flathub/frontend/pull/276

I'm still puzzled, why we think it shouldn't be `installs` in the frontend, as I find that much clearer from a user POV.