### PR TITLE
Add vcs-browser and contribute URL type

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -138,7 +138,7 @@ def appstream2dict(reponame: str):
             app["urls"] = {}
             for url in urls:
                 component.remove(url)
-                url_type = url.attrib.get("type")
+                url_type = url.attrib.get("type").replace("-", "_")
                 if url_type:
                     app["urls"][url_type] = url.text
 

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -41,6 +41,8 @@
     "help": "Help",
     "contribute-translations": "Contribute Translations",
     "report-an-issue": "Report an Issue",
+    "vcs_browser": "Browse the source code",
+    "contribute": "Contribute to the App",
     "no-changelog-provided": "No changelog provided",
     "changes-in-version": "Changes in version {{version-number}}",
     "manual-install": "Manual Install",

--- a/frontend/src/components/application/AdditionalInfo.tsx
+++ b/frontend/src/components/application/AdditionalInfo.tsx
@@ -11,6 +11,8 @@ import {
   MdQuestionAnswer,
   MdTranslate,
   MdWeb,
+  MdCode,
+  MdEngineering,
 } from 'react-icons/md'
 import { BsHddFill, BsTextParagraph } from 'react-icons/bs'
 import { MdLaptop } from 'react-icons/md'
@@ -220,7 +222,7 @@ const AdditionalInfo = ({
           items={[
             data.urls.vcs_browser
               ? {
-                icon: <MdWeb />,
+                icon: <MdCode />,
                 header: t('vcs_browser'),
                 content: {
                   type: 'url',
@@ -238,7 +240,7 @@ const AdditionalInfo = ({
           items={[
             data.urls.contribute
               ? {
-                icon: <MdWeb />,
+                icon: <MdEngineering />,
                 header: t('contribute'),
                 content: {
                   type: 'url',

--- a/frontend/src/components/application/AdditionalInfo.tsx
+++ b/frontend/src/components/application/AdditionalInfo.tsx
@@ -214,6 +214,42 @@ const AdditionalInfo = ({
           ]}
         />
       )}
+       {data.urls?.vcs_browser && (
+        <ListBox
+          appId={appId}
+          items={[
+            data.urls.vcs_browser
+              ? {
+                icon: <MdWeb />,
+                header: t('vcs_browser'),
+                content: {
+                  type: 'url',
+                  text: data.urls.vcs_browser,
+                  trackAsEvent: 'VCS_Browser',
+                },
+              }
+              : undefined,
+          ]}
+        />
+      )}
+       {data.urls?.contribute && (
+        <ListBox
+          appId={appId}
+          items={[
+            data.urls.contribute
+              ? {
+                icon: <MdWeb />,
+                header: t('contribute'),
+                content: {
+                  type: 'url',
+                  text: data.urls.contribute,
+                  trackAsEvent: 'Contribute',
+                },
+              }
+              : undefined,
+          ]}
+        />
+      )}
       <ListBox
         appId={appId}
         items={[

--- a/frontend/src/types/Appstream.ts
+++ b/frontend/src/types/Appstream.ts
@@ -60,6 +60,8 @@ export interface Urls {
   help: string
   faq: string
   contact: string
+  vcs_browser: string
+  contribute: string
 }
 
 export interface Screenshot {

--- a/frontend/src/types/ProjectUrl.ts
+++ b/frontend/src/types/ProjectUrl.ts
@@ -6,3 +6,5 @@ export type ProjectUrl =
   | 'Help'
   | 'Faq'
   | 'Homepage'
+  | 'VCS_Browser'
+  | 'Contribute'


### PR DESCRIPTION
These 2 URL types [have been added to AppStream](https://github.com/ximion/appstream/pull/392). This PR this Links to the new Website. They are already [supported by appstream-glib](https://github.com/hughsie/appstream-glib/pull/438), but not in a stable release yet, so it's currently not possible to upload a AppStream file with this new types to Flathub. This PR has not been tested yet. We may also need better Icons.