### PR TITLE
Add page traversal to transaction history

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -185,5 +185,9 @@
     "stripe-error-payment_intent_authentication_failure": "Failed to authenticate your payment method. Please choose a different payment method and try again.",
     "stripe-error-processing_error": "An error occurred while processing the card. Try again later or with a different payment method.",
     "stripe-validation-error": "An invalid card detail was entered.",
-    "view-wallet": "View Wallet"
+    "view-wallet": "View Wallet",
+    "no-more-transactions": "No more transactions to show.",
+    "first-page": "First Page",
+    "previous-page": "Previous Page",
+    "next-page": "Next Page"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -187,7 +187,6 @@
     "stripe-validation-error": "An invalid card detail was entered.",
     "view-wallet": "View Wallet",
     "no-more-transactions": "No more transactions to show.",
-    "first-page": "First Page",
     "previous-page": "Previous Page",
     "next-page": "Next Page"
 }

--- a/frontend/src/components/Button.module.scss
+++ b/frontend/src/components/Button.module.scss
@@ -11,12 +11,12 @@
   font-size: 1rem;
   font-weight: 500;
 
-  &:hover {
+  &:hover:not(:disabled) {
     cursor: pointer;
     background-color: var(--color-secondary);
   }
 
-  &:active {
+  &:active:not(:disabled) {
     background-color: var(--bg-color-primary);
   }
 
@@ -34,13 +34,13 @@
   background-image: unset;
   border: 1px solid var(--color-secondary);
 
-  &:hover {
+  &:hover:not(:disabled) {
     cursor: pointer;
     background-color: var(--color-primary);
     color: var(--white-10);
   }
 
-  &:active {
+  &:active:not(:disabled) {
     background-color: var(--bg-color-primary);
   }
 

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -8,10 +8,22 @@ interface Props {
   buttonType?: 'button' | 'submit' | 'reset'
   disabled?: boolean
   className?: string
+  'aria-label'?: string
 }
 
 const Button: FunctionComponent<Props> = forwardRef<HTMLButtonElement, Props>(
-  ({ children, onClick, type, buttonType, disabled = false, className }, ref) => {
+  (
+    {
+      children,
+      onClick,
+      type,
+      buttonType,
+      disabled = false,
+      className,
+      'aria-label': ariaLabel,
+    },
+    ref
+  ) => {
     return (
       <button
         className={
@@ -25,6 +37,7 @@ const Button: FunctionComponent<Props> = forwardRef<HTMLButtonElement, Props>(
         ref={ref}
         type={buttonType}
         disabled={disabled}
+        aria-label={ariaLabel}
       >
         {children}
       </button>

--- a/frontend/src/components/payment/transactions/TransactionHistory.module.scss
+++ b/frontend/src/components/payment/transactions/TransactionHistory.module.scss
@@ -1,0 +1,4 @@
+.controlPage {
+  display: flex;
+  gap: 20px;
+}

--- a/frontend/src/components/payment/transactions/TransactionHistory.module.scss
+++ b/frontend/src/components/payment/transactions/TransactionHistory.module.scss
@@ -1,4 +1,9 @@
 .controlPage {
   display: flex;
   gap: 20px;
+  justify-content: center;
+
+  .navButton {
+    font-size: 24px;
+  }
 }

--- a/frontend/src/components/payment/transactions/TransactionHistory.tsx
+++ b/frontend/src/components/payment/transactions/TransactionHistory.tsx
@@ -8,6 +8,7 @@ import Button from '../../Button'
 import Spinner from '../../Spinner'
 import TransactionList from './TransactionList'
 import styles from './TransactionHistory.module.scss'
+import { MdNavigateBefore, MdNavigateNext } from 'react-icons/md'
 
 async function getTransactions(
   sort: string = 'recent',
@@ -87,6 +88,8 @@ const TransactionHistory: FunctionComponent = () => {
     return <Spinner size={100} text={t('loading')} />
   }
 
+  const pageSlice = transactions.slice(page * perPage, page * perPage + perPage)
+
   return (
     <div className='main-container'>
       <h3>{t('transaction-history')}</h3>
@@ -94,29 +97,23 @@ const TransactionHistory: FunctionComponent = () => {
         <p>{t(error)}</p>
       ) : (
         <>
-          <TransactionList
-            transactions={transactions.slice(
-              page * perPage,
-              page * perPage + perPage
-            )}
-          />
+          <TransactionList transactions={pageSlice} />
           <div className={styles.controlPage}>
             <Button
               type='secondary'
-              onClick={() => setPage(0)}
+              onClick={pageBack}
               disabled={page === 0}
+              aria-label={t('previous-page')}
             >
-              {t('first-page')}
-            </Button>
-            <Button type='secondary' onClick={pageBack} disabled={page === 0}>
-              {t('previous-page')}
+              <MdNavigateBefore className={styles.navButton} />
             </Button>
             <Button
               type='secondary'
               onClick={pageForward}
-              disabled={page === endPage}
+              disabled={page === endPage || perPage > pageSlice.length}
+              aria-label={t('next-page')}
             >
-              {t('next-page')}
+              <MdNavigateNext className={styles.navButton} />
             </Button>
           </div>
         </>


### PR DESCRIPTION
- Can't use arbitrary page jumping since retrieval API works sequentially, so user can use "next" and "previous" page buttons (or jump to start)
- Selecting sorting complicates the logic and has been left out for now

Part of #134