### PR TITLE
Add LoginGuard convenience wrapper component

### DIFF
--- a/frontend/pages/donate.tsx
+++ b/frontend/pages/donate.tsx
@@ -2,40 +2,22 @@ import { GetStaticProps } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
-import Router from 'next/router'
-import { ReactElement, useEffect } from 'react'
 import Main from '../src/components/layout/Main'
+import LoginGuard from '../src/components/login/LoginGuard'
 import DonationInput from '../src/components/payment/DonationInput'
-import Spinner from '../src/components/Spinner'
-import { useUserContext } from '../src/context/user-info'
 
 export default function Donate() {
   const { t } = useTranslation()
-  const user = useUserContext()
-
-  // Must be logged in to donate
-  useEffect(() => {
-    if (!user.info && !user.loading) {
-      Router.push('/login')
-    }
-  }, [user])
-
-  let content: ReactElement
-  if (user.loading || !user.info) {
-    content = <Spinner size={150} />
-  } else {
-    content = (
-      <div className='main-container'>
-        <h2>{t('donate-to', { project: 'Flathub' })}</h2>
-        <DonationInput org='org.flathub.Flathub' />
-      </div>
-    )
-  }
 
   return (
     <Main>
       <NextSeo title={t('donate-to', { project: 'Flathub' })} />
-      {content}
+      <div className='main-container'>
+        <LoginGuard>
+          <h2>{t('donate-to', { project: 'Flathub' })}</h2>
+          <DonationInput org='org.flathub.Flathub' />
+        </LoginGuard>
+      </div>
     </Main>
   )
 }

--- a/frontend/pages/userpage.tsx
+++ b/frontend/pages/userpage.tsx
@@ -2,44 +2,27 @@ import { GetStaticProps } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
-import Router from 'next/router'
-import { ReactElement, useEffect } from 'react'
 import Main from '../src/components/layout/Main'
-import Spinner from '../src/components/Spinner'
+import LoginGuard from '../src/components/login/LoginGuard'
 import UserDetails from '../src/components/user/Details'
 import UserApps from '../src/components/user/UserApps'
-import { useUserContext } from '../src/context/user-info'
 import { fetchLoginProviders } from '../src/fetchers'
 import { LoginProvider } from '../src/types/Login'
 import styles from './userpage.module.scss'
 
 export default function Userpage({ providers }) {
   const { t } = useTranslation()
-  const user = useUserContext()
 
-  // Nothing to show if not logged in, return to home
-  useEffect(() => {
-    if (!user.info && !user.loading) {
-      Router.push('/')
-    }
-  }, [user])
-
-  let content: ReactElement
-  if (user.loading || !user.info) {
-    content = <Spinner size={150} />
-  } else {
-    // Buttons above apps so they're on screen when page loads (for action visibility)
-    content =
-      <div className={styles.userArea}>
-        <UserDetails logins={providers} />
-        <UserApps />
-      </div>
-  }
-
+  // Buttons above apps so they're on screen when page loads (for action visibility)
   return (
     <Main>
       <NextSeo title={t('user-page')} noindex={true} />
-      {content}
+      <div className={styles.userArea}>
+        <LoginGuard>
+          <UserDetails logins={providers} />
+          <UserApps />
+        </LoginGuard>
+      </div>
     </Main>
   )
 }
@@ -52,6 +35,6 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale, ['common'])),
       providers,
-    }
+    },
   }
 }

--- a/frontend/pages/wallet.tsx
+++ b/frontend/pages/wallet.tsx
@@ -2,44 +2,26 @@ import { GetStaticProps } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
-import Router from 'next/router'
-import { ReactElement, useEffect } from 'react'
 import Main from '../src/components/layout/Main'
+import LoginGuard from '../src/components/login/LoginGuard'
 import SavedCards from '../src/components/payment/cards/SavedCards'
 import TransactionHistory from '../src/components/payment/transactions/TransactionHistory'
-import Spinner from '../src/components/Spinner'
-import { useUserContext } from '../src/context/user-info'
 import styles from './userpage.module.scss'
 
 // This is a proof of concept page, ideally this information will be
 // integrated into the user page as a tab or similar
 export default function Wallet() {
   const { t } = useTranslation()
-  const user = useUserContext()
-
-  // Nothing to show if not logged in, return to home
-  useEffect(() => {
-    if (!user.info && !user.loading) {
-      Router.push('/')
-    }
-  }, [user])
-
-  let content: ReactElement
-  if (user.loading || !user.info) {
-    content = <Spinner size={150} />
-  } else {
-    content = (
-      <div className={styles.userArea}>
-        <SavedCards />
-        <TransactionHistory />
-      </div>
-    )
-  }
 
   return (
     <Main>
       <NextSeo title={t('user-wallet')} noindex={true} />
-      {content}
+      <div className={styles.userArea}>
+        <LoginGuard>
+          <SavedCards />
+          <TransactionHistory />
+        </LoginGuard>
+      </div>
     </Main>
   )
 }

--- a/frontend/src/components/login/LoginGuard.tsx
+++ b/frontend/src/components/login/LoginGuard.tsx
@@ -1,0 +1,28 @@
+import { useRouter } from 'next/router'
+import { FunctionComponent, useEffect } from 'react'
+import { useUserContext } from '../../context/user-info'
+import Spinner from '../Spinner'
+
+/**
+This is essentially a wrapper component to conditionally render the
+content within only once the user is confirmed to be logged in.
+
+If user is logged out, they will be redirected to login.
+
+TODO: Redirect back upon login completion
+*/
+const LoginGuard: FunctionComponent = ({ children }) => {
+  const user = useUserContext()
+  const router = useRouter()
+
+  // Content unsuitable if not logged in, send user to login page
+  useEffect(() => {
+    if (!user.info && !user.loading) {
+      router.push('/login')
+    }
+  }, [user, router])
+
+  return user.loading || !user.info ? <Spinner size={150} /> : <>{children}</>
+}
+
+export default LoginGuard


### PR DESCRIPTION
- An easy way to only render a page's content when we know the user is logged in. Otherwise redirecting them to login.
- Simplifies some code by factoring this pattern out to a new component.
- For user QoL it would be handy if this redirected back to the same page following login, but need to think further about how best to handle that (probably local storage, but would need to guard against unexpected redirection if user doesn't login then later does).