### PR TITLE
Add vending link to userpage

### DIFF
--- a/backend/app/vending/__init__.py
+++ b/backend/app/vending/__init__.py
@@ -54,6 +54,7 @@ class VendingStatus(BaseModel):
     status: str
     can_take_payments: bool
     needs_attention: bool
+    details_submitted: bool
 
 
 class VendingOnboardingRequest(BaseModel):
@@ -117,11 +118,15 @@ def status(login=Depends(login_state)) -> VendingStatus:
         needs_attention = (
             len(acc.get("requirements", {}).get("currently_due", ["..."])) > 0
         )
+        details_submitted = acc.get("details_submitted")
     except Exception as error:
         raise VendingError("stripe-account-retrieval-failed") from error
 
     return VendingStatus(
-        status="ok", can_take_payments=can_take_money, needs_attention=needs_attention
+        status="ok",
+        can_take_payments=can_take_money,
+        needs_attention=needs_attention,
+        details_submitted=details_submitted,
     )
 
 

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -196,5 +196,9 @@
   "no-more-transactions": "No more transactions to show.",
   "previous-page": "Previous Page",
   "next-page": "Next Page",
-  "less": "Less"
+  "less": "Less",
+  "accepting-payment": "Accepting Payment",
+  "vending-dashboard": "Go to your Stripe Express account",
+  "vending-onboard": "Create a Stripe Express account",
+  "requires-attention": "Requires attention"
 }

--- a/frontend/src/asyncs/vending.ts
+++ b/frontend/src/asyncs/vending.ts
@@ -1,0 +1,80 @@
+import {
+  VENDING_DASHBOARD_URL,
+  VENDING_ONBOARDING_URL,
+  VENDING_STATUS_URL,
+} from "../env"
+import { VendingRedirect, VendingStatus } from "../types/Vending"
+
+// API responds with this status code if onboarding has not begun
+const STATUS_NEW = 201
+
+const DEFAULT_STATUS: VendingStatus = {
+  can_take_payments: false,
+  details_submitted: false,
+  needs_attention: false,
+}
+
+/**
+ * Retrieve the vending status of the logged in user.
+ * @returns The vending status object
+ */
+export async function getVendingStatus(): Promise<VendingStatus> {
+  let res: Response
+  try {
+    res = await fetch(VENDING_STATUS_URL, { credentials: "include" })
+  } catch {
+    throw "failed-to-load-refresh"
+  }
+
+  if (res.ok) {
+    if (res.status === STATUS_NEW) {
+      return DEFAULT_STATUS
+    }
+
+    const data: VendingStatus = await res.json()
+    return data
+  } else {
+    throw "failed-to-load-refresh"
+  }
+}
+
+export async function getDashboardLink(): Promise<string> {
+  let res: Response
+  try {
+    res = await fetch(VENDING_DASHBOARD_URL, { credentials: "include" })
+  } catch {
+    throw "failed-to-load-refresh"
+  }
+
+  if (res.ok) {
+    const data: VendingRedirect = await res.json()
+    return data.target_url
+  } else {
+    throw "failed-to-load-refresh"
+  }
+}
+
+export async function getOnboardingLink(): Promise<string> {
+  let res: Response
+  try {
+    res = await fetch(VENDING_ONBOARDING_URL, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        return_url: `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/userpage`,
+      }),
+    })
+  } catch {
+    throw "network-error-try-again"
+  }
+
+  if (res.ok) {
+    const data: VendingRedirect = await res.json()
+    return data.target_url
+  } else {
+    throw "network-error-try-again"
+  }
+}

--- a/frontend/src/components/user/Details.module.scss
+++ b/frontend/src/components/user/Details.module.scss
@@ -1,7 +1,7 @@
 .details {
   display: grid;
   grid-template-columns: auto 200px;
-  grid-template-rows: auto auto;
+  grid-template-rows: auto auto auto;
 
   padding: 16px 8px 16px 16px;
 
@@ -60,13 +60,12 @@
 
   .actions {
     grid-row-start: 1;
-    grid-row-end: 3;
+    grid-row-end: 4;
 
     margin-left: auto;
     display: flex;
     flex-direction: column;
     gap: 8px;
-    justify-content: center;
 
     button {
       display: flex;

--- a/frontend/src/components/user/Details.tsx
+++ b/frontend/src/components/user/Details.tsx
@@ -8,6 +8,7 @@ import LogoutButton from "../login/LogoutButton"
 import ProviderLink from "../login/ProviderLink"
 import DeleteButton from "./DeleteButton"
 import styles from "./Details.module.scss"
+import VendingLink from "./VendingLink"
 
 interface Props {
   logins: LoginProvider[]
@@ -69,6 +70,15 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
         </div>
 
         {loginSection}
+
+        {user.info["dev-flatpaks"].length ? (
+          <div className={styles.subsection}>
+            <h3>{t("accepting-payment")}</h3>
+            <VendingLink />
+          </div>
+        ) : (
+          <></>
+        )}
 
         <div className={styles.actions}>
           <Link href="/wallet" passHref>

--- a/frontend/src/components/user/VendingLink.module.scss
+++ b/frontend/src/components/user/VendingLink.module.scss
@@ -1,0 +1,8 @@
+.link {
+  display: flex;
+  flex-direction: column;
+
+  p {
+    margin: 0;
+  }
+}

--- a/frontend/src/components/user/VendingLink.tsx
+++ b/frontend/src/components/user/VendingLink.tsx
@@ -1,0 +1,100 @@
+import { useTranslation } from "next-i18next"
+import { FunctionComponent, useEffect } from "react"
+import { toast } from "react-toastify"
+import {
+  getDashboardLink,
+  getOnboardingLink,
+  getVendingStatus,
+} from "../../asyncs/vending"
+import { useAsync } from "../../hooks/useAsync"
+import Button from "../Button"
+import Spinner from "../Spinner"
+import styles from "./VendingLink.module.scss"
+
+/**
+ * A link to the user's account for donations and payments. Will be one of:
+ *
+ * - Onboarding button
+ * - Dashboard link (possibly with "attention needed" text)
+ */
+const VendingLink: FunctionComponent = () => {
+  const { t } = useTranslation()
+
+  // Status fetched when component mounts to determine what user sees
+  const {
+    status: getStatusRequest,
+    value: status,
+    error: statusError,
+  } = useAsync(getVendingStatus)
+
+  const {
+    execute: getDashboard,
+    status: getDashboardRequest,
+    value: dashboardLink,
+    error: dashboardError,
+  } = useAsync(getDashboardLink, false)
+  const {
+    execute: getOnboarding,
+    status: getOnboardingRequest,
+    value: onboardingLink,
+    error: onboardingError,
+  } = useAsync(getOnboardingLink, false)
+
+  // If payments can be taken, onboarding was complete
+  useEffect(() => {
+    if (status && status.can_take_payments) {
+      getDashboard()
+    }
+  }, [status, getDashboard])
+
+  // Redirect to onboard occurs if successfully retrieved, user sent back after
+  useEffect(() => {
+    if (onboardingLink) {
+      window.location.href = onboardingLink
+    }
+  }, [status, onboardingLink])
+
+  useEffect(() => {
+    if (onboardingError) {
+      toast.error(t(onboardingError))
+    }
+  }, [onboardingError, t])
+
+  // Multiple stages of loading
+  if (
+    getStatusRequest === "pending" ||
+    getDashboardRequest === "pending" ||
+    ["pending", "success"].includes(getOnboardingRequest)
+  ) {
+    return <Spinner size={30} />
+  }
+
+  if (statusError || dashboardError) {
+    return <p>{t(statusError || dashboardError)}</p>
+  }
+
+  // No status when onboarding hasn't begun
+  // Can't pre-fetch link, it will create an account without user action
+  if (!status || !status.details_submitted) {
+    return (
+      <Button variant="primary" onClick={getOnboarding}>
+        {t("vending-onboard")}
+      </Button>
+    )
+  }
+
+  return (
+    <div className={styles.link}>
+      <a target="_blank" rel="noreferrer" href={dashboardLink}>
+        {t("vending-dashboard")}
+      </a>
+      {status.needs_attention ? (
+        <p style={{ color: "red" }}>{t("requires-attention")}</p>
+      ) : (
+        <></>
+      )}
+    </div>
+  )
+}
+
+export default VendingLink

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -64,5 +64,9 @@ export const TRANSACTION_CANCEL_URL = (transaction: string) => {
   return `${TRANSACTION_INFO_URL(transaction)}/cancel`
 }
 
+export const VENDING_STATUS_URL = `${BASE_URI}/vending/status`
+export const VENDING_ONBOARDING_URL = `${VENDING_STATUS_URL}/onboarding`
+export const VENDING_DASHBOARD_URL = `${VENDING_STATUS_URL}/dashboardlink`
+
 export const IS_PRODUCTION: boolean =
   process.env.NEXT_PUBLIC_IS_PRODUCTION === "true"

--- a/frontend/src/types/Vending.ts
+++ b/frontend/src/types/Vending.ts
@@ -1,0 +1,9 @@
+export interface VendingStatus {
+  can_take_payments: boolean
+  needs_attention: boolean
+  details_submitted: boolean
+}
+
+export interface VendingRedirect {
+  target_url: string
+}


### PR DESCRIPTION
- Only shown if user has 1 or more apps
- Uses the vending API to check status of signed-in user's external vending account
- Presents either onboarding button or dashboard link as needed
- Alerts user to update their account if attention is needed

A little unsure how best to present these elements , but have opted for 

- A subsection (not 100% happy with my chosen heading) at the bottom of the user page's top element (below linked accounts)
- A button to begin onboarding - because clicking it initiates an action to fetch an onboarding link and sends browser there (user is redirected back upon completion). This link can't be pre-fetched otherwise Express accounts will be created without user action.
- A plain link to the Stripe Express dashboard after onboarding (so that it can open in a new window), with conditional red text shown underneath when the account needs attention from the user (as reported by the API)

Here's how it looks on the user page before (and during incomplete) onboarding:
![Screenshot from 2022-04-25 15-18-29](https://user-images.githubusercontent.com/5459452/165109463-fee01598-90e6-4e14-b4d7-0bfabb325afd.png)

After onboarding but when my test details fail to validate:

![Screenshot from 2022-04-25 15-36-41](https://user-images.githubusercontent.com/5459452/165111733-3cdd483b-f994-46a6-8bf1-3929709349aa.png)


