### PR TITLE
Add confirmation to card deletion

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -200,5 +200,7 @@
   "accepting-payment": "Accepting Payment",
   "vending-dashboard": "Go to your Stripe Express account",
   "vending-onboard": "Create a Stripe Express account",
-  "requires-attention": "Requires attention"
+  "requires-attention": "Requires attention",
+  "cancel": "Cancel",
+  "delete": "Delete"
 }

--- a/frontend/src/components/payment/cards/DeleteCardButton.module.scss
+++ b/frontend/src/components/payment/cards/DeleteCardButton.module.scss
@@ -1,0 +1,9 @@
+.confirmContainer {
+  display: flex;
+  gap: 16px;
+  justify-content: space-evenly;
+
+  .mdButton {
+    font-size: 24px;
+  }
+}

--- a/frontend/src/components/payment/cards/DeleteCardButton.tsx
+++ b/frontend/src/components/payment/cards/DeleteCardButton.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from "next-i18next"
+import { FunctionComponent, useCallback, useEffect, useState } from "react"
+import { MdCancel, MdDelete } from "react-icons/md"
+import { toast } from "react-toastify"
+import { deletePaymentCard } from "../../../asyncs/payment"
+import { useAsync } from "../../../hooks/useAsync"
+import { PaymentCard } from "../../../types/Payment"
+import Button from "../../Button"
+import Spinner from "../../Spinner"
+import styles from "./DeleteCardButton.module.scss"
+
+interface Props {
+  card: PaymentCard
+  onSuccess: (card: PaymentCard) => void
+}
+
+const DeleteCardButton: FunctionComponent<Props> = ({ card, onSuccess }) => {
+  const { t } = useTranslation()
+
+  const [confirming, setConfirming] = useState(false)
+
+  // The deletion request only happens once confirmed by secondary click
+  const onConfirm = useCallback(() => deletePaymentCard(card), [card])
+  const { execute, status, error } = useAsync(onConfirm, false)
+
+  // If card was deleted backend, dispatch update to reflect in rendering
+  useEffect(() => {
+    if (status === "success") {
+      onSuccess(card)
+    }
+  }, [status, onSuccess, card])
+
+  // If deletion fails, user can always retry
+  useEffect(() => {
+    if (error) {
+      toast.error(t(error))
+      setConfirming(false)
+    }
+  }, [error, t])
+
+  if (status === "pending") {
+    return <Spinner size={30} />
+  }
+
+  if (confirming) {
+    return (
+      <div className={styles.confirmContainer}>
+        <Button
+          variant="secondary"
+          onClick={() => setConfirming(false)}
+          aria-label={t("cancel")}
+          title={t("cancel")}
+        >
+          <MdCancel className={styles.mdButton} />
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={execute}
+          aria-label={t("delete")}
+          title={t("delete")}
+        >
+          <MdDelete className={styles.mdButton} />
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <Button variant="secondary" onClick={() => setConfirming(true)}>
+      {t("remove-saved-card")}
+    </Button>
+  )
+}
+
+export default DeleteCardButton

--- a/frontend/src/components/payment/cards/SavedCards.module.scss
+++ b/frontend/src/components/payment/cards/SavedCards.module.scss
@@ -4,4 +4,10 @@
 
   padding: 20px;
   gap: 20px;
+
+  .cardContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 }

--- a/frontend/src/components/payment/cards/SavedCards.tsx
+++ b/frontend/src/components/payment/cards/SavedCards.tsx
@@ -1,80 +1,63 @@
 import { useTranslation } from "next-i18next"
-import { FunctionComponent, ReactElement, useEffect, useState } from "react"
-import { toast } from "react-toastify"
-import { deletePaymentCard, getPaymentCards } from "../../../asyncs/payment"
-import { useUserContext } from "../../../context/user-info"
+import {
+  FunctionComponent,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useState,
+} from "react"
+import { getPaymentCards } from "../../../asyncs/payment"
+import { useAsync } from "../../../hooks/useAsync"
 import { PaymentCard } from "../../../types/Payment"
-import Button from "../../Button"
 import Spinner from "../../Spinner"
 import CardInfo from "./CardInfo"
+import DeleteCardButton from "./DeleteCardButton"
 import styles from "./SavedCards.module.scss"
 
 const SavedCards: FunctionComponent = () => {
   const { t } = useTranslation()
-  const user = useUserContext()
 
-  const [fetched, setFetched] = useState(false)
-  // User may have no cards saved, so unloaded state is not empty array
-  const [cards, setCards] = useState<PaymentCard[]>(null)
-  const [error, setError] = useState("")
+  const [cards, setCards] = useState<PaymentCard[]>()
 
-  // Cards should only be retrieved once, and can only be when logged in
-  useEffect(() => {
-    if (user.info && !fetched) {
-      setFetched(true)
-      getPaymentCards().then(setCards).catch(setError)
-    }
-  }, [user, fetched])
+  // Callback ensures components aren't rerendered until data changes
+  const removeCard = useCallback(
+    (toRemove: PaymentCard) => {
+      setCards(cards.filter((card) => card.id !== toRemove.id))
+    },
+    [cards],
+  )
 
-  // Nothing to show if not logged in
-  if (!user.info) {
-    return <></>
-  }
+  // Saved cards fetched only when component mounts
+  const { status, value, error } = useAsync(getPaymentCards)
+  useEffect(() => setCards(value), [value])
 
-  if (!cards && !error) {
+  // Component considered loading until cards fetched
+  if (["idle", "pending"].includes(status)) {
     return <Spinner size={100} text={t("loading-saved-payment-methods")} />
   }
 
   let content: ReactElement
-  if (!error && cards.length) {
+  if (error || !cards.length) {
+    content = <p>{error ? t(error) : t("no-saved-payment-methods")}</p>
+  } else {
     content = (
-      <>
+      <div className={styles.cardList}>
         {cards.map((card) => (
           <div key={card.id}>
             <CardInfo card={card} />
-            <Button variant="secondary" onClick={() => removeCard(card)}>
-              {t("remove-saved-card")}
-            </Button>
+            <DeleteCardButton card={card} onSuccess={removeCard} />
           </div>
         ))}
-      </>
+      </div>
     )
-  } else {
-    content = <p>{error ? t(error) : t("no-saved-payment-methods")}</p>
   }
 
   return (
     <div className="main-container">
       <h3>{t("saved-cards")}</h3>
-      <div className={styles.cardList}>{content}</div>
+      {content}
     </div>
   )
-
-  /**
-   * Sends API request to delete a saved card, then removes the local rendered copy
-   * @param toRemove the card to be removed
-   */
-  function removeCard(toRemove: PaymentCard) {
-    deletePaymentCard(toRemove)
-      .then(() => {
-        const cardsCopy = cards.slice()
-
-        cardsCopy.splice(cards.findIndex((card) => card.id === toRemove.id))
-
-        setCards(cardsCopy)
-      })
-      .catch((err) => toast.error(t(err)))
-  }
 }
 
 export default SavedCards

--- a/frontend/src/components/payment/cards/SavedCards.tsx
+++ b/frontend/src/components/payment/cards/SavedCards.tsx
@@ -43,7 +43,7 @@ const SavedCards: FunctionComponent = () => {
     content = (
       <div className={styles.cardList}>
         {cards.map((card) => (
-          <div key={card.id}>
+          <div key={card.id} className={styles.cardContainer}>
             <CardInfo card={card} />
             <DeleteCardButton card={card} onSuccess={removeCard} />
           </div>


### PR DESCRIPTION
Bit more awkward than expected since the state of the parent component needs to be updated on success. I originally opted to use a reducer, but this state is a simple array so went with a callback to remove cards in the end and reduce coupling slightly.

Clicking the remove saved card button now prompts to confirm or cancel (with tooltips shown on hover and aira-labels for sceeen readers):

![Screenshot from 2022-05-04 11-31-56](https://user-images.githubusercontent.com/5459452/166665655-33d2d0a9-8270-47be-aa59-4184ea14080c.png)
