### PR TITLE
Fix indefinite loading of no transaction history

### DIFF
--- a/frontend/src/components/payment/transactions/TransactionHistory.tsx
+++ b/frontend/src/components/payment/transactions/TransactionHistory.tsx
@@ -25,7 +25,7 @@ const TransactionHistory: FunctionComponent = () => {
   useEffect(() => {
     function addNewPage(newPage: Transaction[]) {
       // Upon reaching no more transactions, stop traversing
-      if (newPage.length === 0) {
+      if (page > 0 && newPage.length === 0) {
         setEndPage(page - 1)
         setPage(page - 1)
         toast.info(t("no-more-transactions"))


### PR DESCRIPTION
When the returned array length is 0 for the first page, the request was not a result of user action so the transactions state should be set to the empty array and no toast notification should be shown