### PR TITLE
Add convenient navigation links to checkout pages

### DIFF
--- a/frontend/pages/payment/[transaction_id].tsx
+++ b/frontend/pages/payment/[transaction_id].tsx
@@ -7,6 +7,7 @@ import { NextSeo } from "next-seo"
 import { useRouter } from "next/router"
 import { ReactElement, useEffect, useState } from "react"
 import Checkout from "../../src/components/payment/checkout/Checkout"
+import RelatedLink from "../../src/components/RelatedLink"
 import Spinner from "../../src/components/Spinner"
 import { useUserContext } from "../../src/context/user-info"
 import {
@@ -144,7 +145,10 @@ export default function TransactionPage() {
   return (
     <>
       <NextSeo title={t("payment")} noindex={true}></NextSeo>
-      <div className="main-container">{content}</div>
+      <div className="main-container">
+        <RelatedLink href="/wallet" pageTitle={t("user-wallet")} />
+        {content}
+      </div>
     </>
   )
 }

--- a/frontend/pages/payment/details/[transaction_id].tsx
+++ b/frontend/pages/payment/details/[transaction_id].tsx
@@ -6,6 +6,7 @@ import Link from "next/link"
 import { useRouter } from "next/router"
 import { ReactElement, useEffect, useState } from "react"
 import Button from "../../../src/components/Button"
+import RelatedLink from "../../../src/components/RelatedLink"
 import TransactionCancelButton from "../../../src/components/payment/transactions/TransactionCancelButton"
 import TransactionDetails from "../../../src/components/payment/transactions/TransactionDetails"
 import Spinner from "../../../src/components/Spinner"
@@ -95,7 +96,10 @@ export default function TransactionPage() {
   return (
     <>
       <NextSeo title={t("payment-summary")} noindex={true}></NextSeo>
-      <div className="main-container">{content}</div>
+      <div className="main-container">
+        <RelatedLink href="/wallet" pageTitle={t("user-wallet")} />
+        {content}
+      </div>
     </>
   )
 }

--- a/frontend/pages/wallet.tsx
+++ b/frontend/pages/wallet.tsx
@@ -3,9 +3,9 @@ import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NextSeo } from "next-seo"
 import LoginGuard from "../src/components/login/LoginGuard"
+import RelatedLink from "../src/components/RelatedLink"
 import SavedCards from "../src/components/payment/cards/SavedCards"
 import TransactionHistory from "../src/components/payment/transactions/TransactionHistory"
-import styles from "./userpage.module.scss"
 
 // This is a proof of concept page, ideally this information will be
 // integrated into the user page as a tab or similar
@@ -15,7 +15,8 @@ export default function Wallet() {
   return (
     <>
       <NextSeo title={t("user-wallet")} noindex={true} />
-      <div className={styles.userArea}>
+      <div className="main-container">
+        <RelatedLink href="/userpage" pageTitle={t("user-page")} />
         <LoginGuard>
           <SavedCards />
           <TransactionHistory />

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -202,5 +202,6 @@
   "vending-onboard": "Create a Stripe Express account",
   "requires-attention": "Requires attention",
   "cancel": "Cancel",
-  "delete": "Delete"
+  "delete": "Delete",
+  "go-to-page": "Go to {{page}}"
 }

--- a/frontend/src/components/RelatedLink.tsx
+++ b/frontend/src/components/RelatedLink.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from "next-i18next"
+import Link from "next/link"
+import { FunctionComponent } from "react"
+import { MdKeyboardArrowLeft } from "react-icons/md"
+
+interface Props {
+  href: string
+  pageTitle: string
+}
+
+/** A link placed at the top of a page's main container to return to some other page
+ */
+const RelatedLink: FunctionComponent<Props> = ({ href, pageTitle }) => {
+  const { t } = useTranslation()
+
+  return (
+    <Link href={href} passHref>
+      <a style={{ display: "flex", alignItems: "center", marginTop: "8px" }}>
+        <MdKeyboardArrowLeft style={{ fontSize: "32px" }} />{" "}
+        {t("go-to-page", { page: pageTitle })}
+      </a>
+    </Link>
+  )
+}
+
+export default RelatedLink


### PR DESCRIPTION
A small "Go to X" type of link at the top of the page content for easy return to where a user came from (or to a related page)

![Screenshot from 2022-05-04 14-07-41](https://user-images.githubusercontent.com/5459452/166687523-74581fa3-01bc-444d-bee9-2a0d0cab92cd.png)


Part of #134