### PR TITLE
Direct user back to where they were upon login

### DIFF
--- a/frontend/pages/login/[service].tsx
+++ b/frontend/pages/login/[service].tsx
@@ -11,6 +11,7 @@ import { useUserContext, useUserDispatch } from "../../src/context/user-info"
 import { fetchLoginProviders } from "../../src/fetchers"
 import { useLocalStorage } from "../../src/hooks/useLocalStorage"
 import { usePendingTransaction } from "../../src/hooks/usePendingTransaction"
+import { isInternalRedirect } from "../../src/utils/security"
 
 export default function AuthReturnPage({ services }) {
   // Must access query params to POST to backend for oauth verification
@@ -32,8 +33,15 @@ export default function AuthReturnPage({ services }) {
       if (pendingTransaction) {
         router.push("/purchase")
       } else if (returnTo) {
-        router.push(decodeURIComponent(returnTo))
+        const redirect = decodeURIComponent(returnTo)
         setReturnTo(null)
+
+        // Must validate the redirect to prevent open redirect and code execution
+        if (isInternalRedirect(redirect)) {
+          router.push(redirect)
+        } else {
+          router.push("/userpage")
+        }
       } else {
         router.push("/userpage")
       }

--- a/frontend/pages/login/[service].tsx
+++ b/frontend/pages/login/[service].tsx
@@ -9,6 +9,7 @@ import { login } from "../../src/asyncs/login"
 import Spinner from "../../src/components/Spinner"
 import { useUserContext, useUserDispatch } from "../../src/context/user-info"
 import { fetchLoginProviders } from "../../src/fetchers"
+import { useLocalStorage } from "../../src/hooks/useLocalStorage"
 import { usePendingTransaction } from "../../src/hooks/usePendingTransaction"
 
 export default function AuthReturnPage({ services }) {
@@ -23,12 +24,16 @@ export default function AuthReturnPage({ services }) {
   const dispatch = useUserDispatch()
 
   const [pendingTransaction, _setPendingTransaction] = usePendingTransaction()
+  const [returnTo, setReturnTo] = useLocalStorage<string>("returnTo", "")
 
   useEffect(() => {
-    // Redirect to userpage once logged in. Or, if there's a pending transaction, redirect to the purchase page.
+    // Redirect back to where user was, or userpage for unprompted login
     if (user.info && !user.loading) {
       if (pendingTransaction) {
         router.push("/purchase")
+      } else if (returnTo) {
+        router.push(decodeURIComponent(returnTo))
+        setReturnTo(null)
       } else {
         router.push("/userpage")
       }

--- a/frontend/src/components/login/LoginGuard.tsx
+++ b/frontend/src/components/login/LoginGuard.tsx
@@ -7,9 +7,8 @@ import Spinner from "../Spinner"
 This is essentially a wrapper component to conditionally render the
 content within only once the user is confirmed to be logged in.
 
-If user is logged out, they will be redirected to login.
-
-TODO: Redirect back upon login completion
+If user is logged out, they will be redirected to login and then back
+upon completion (via the URL query string).
 */
 const LoginGuard: FunctionComponent = ({ children }) => {
   const user = useUserContext()
@@ -18,7 +17,7 @@ const LoginGuard: FunctionComponent = ({ children }) => {
   // Content unsuitable if not logged in, send user to login page
   useEffect(() => {
     if (!user.info && !user.loading) {
-      router.push("/login")
+      router.push(`/login?returnTo=${encodeURIComponent(router.asPath)}`)
     }
   }, [user, router])
 

--- a/frontend/src/components/login/ProviderLink.tsx
+++ b/frontend/src/components/login/ProviderLink.tsx
@@ -1,7 +1,9 @@
 import { useTranslation } from "next-i18next"
+import { useRouter } from "next/router"
 import { FunctionComponent, useEffect, useState } from "react"
 import { toast } from "react-toastify"
 import { LOGIN_PROVIDERS_URL } from "../../env"
+import { useLocalStorage } from "../../hooks/useLocalStorage"
 import { LoginProvider, LoginRedirect } from "../../types/Login"
 import styles from "./ProviderLink.module.scss"
 
@@ -11,8 +13,12 @@ interface Props {
 
 const ProviderLink: FunctionComponent<Props> = ({ provider }) => {
   const { t } = useTranslation()
+  const router = useRouter()
+
   // Using state to prevent user repeatedly initiating fetches
   const [clicked, setClicked] = useState(false)
+
+  const [, setReturnTo] = useLocalStorage<string>("returnTo", "")
 
   // When user clicks a provider, a redirect is fetched to initiate login flow
   useEffect(() => {
@@ -34,6 +40,7 @@ const ProviderLink: FunctionComponent<Props> = ({ provider }) => {
 
       if (res.ok) {
         const data: LoginRedirect = await res.json()
+        setReturnTo(router.query.returnTo as string)
         window.location.href = data.redirect
       } else {
         toast.error(`${res.status} ${res.statusText}`)
@@ -44,7 +51,7 @@ const ProviderLink: FunctionComponent<Props> = ({ provider }) => {
     if (clicked) {
       redirect(`${LOGIN_PROVIDERS_URL}/${provider.method}`)
     }
-  }, [clicked, provider.method, t])
+  }, [clicked, provider.method, router, setReturnTo, t])
 
   const loginText = t(`login-with-provider`, { provider: provider.name })
 

--- a/frontend/src/utils/security.ts
+++ b/frontend/src/utils/security.ts
@@ -1,0 +1,15 @@
+/**
+ * Checks whether a given string is a URL pointing to the current host.
+ * Should be used before redirecting if untrusted input is involved.
+ * @param url URL string
+ * @returns if the URL points to the current host
+ */
+export function isInternalRedirect(url: string): boolean {
+  try {
+    const parsedRedirect = new URL(url, process.env.NEXT_PUBLIC_SITE_BASE_URI)
+
+    return parsedRedirect.host === location.host
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Since login directs the user away from the site, we need to use local
storage to determine where to send them on return.

However, by sending them to the login page there's no guarantee that
they will go through with login. We don't want to pre-emptively set a
value which will later falsely be used if they return to login.

If that reasoning is unclear, also consider the scenario where a user
has two login windows open as a result of trying to visit different
protected pages. Whichever window they proceed with should direct them
back to where they were in that window, not the other window.

Using a URL query string means the local storage value can be set only
immediately before redirect away from the site, when we know they are
performing login. It can then be used from local storage on return.

If a value does remain in local storage, we prefer the query string
at time of redirect which will overwrite it.