### PR TITLE
feat(frontend): add content-security-policy

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,17 @@
 const { PHASE_PRODUCTION_SERVER } = require("next/constants")
 const { i18n } = require("./next-i18next.config")
 
+const CONTENT_SECURITY_POLICY = `
+  default-src 'none';
+  script-src 'self' https://webstats.gnome.org;
+  style-src 'self' 'unsafe-inline' https://dl.flathub.org;
+  font-src 'self' https://dl.flathub.org;
+  connect-src 'self' https://flathub.org https://webstats.gnome.org;
+  img-src 'self' https://dl.flathub.org https://webstats.gnome.org data:;
+`
+  .replace(/\s{2,}/g, " ")
+  .trim()
+
 module.exports = (phase) => ({
   i18n,
   images: {
@@ -50,9 +61,7 @@ module.exports = (phase) => ({
                * For the development environment we either need to maintain a separate CSP or disable it altogether.
                * This is because it makes use of `eval` and other features that we don't want to allow in the production environment.
                */
-              phase === PHASE_PRODUCTION_SERVER
-                ? "default-src 'none'; script-src 'self' https://webstats.gnome.org; style-src 'self' 'unsafe-inline' https://dl.flathub.org; font-src 'self' https://dl.flathub.org; connect-src 'self' https://flathub.org https://webstats.gnome.org; img-src 'self' https://dl.flathub.org https://webstats.gnome.org data:;"
-                : "",
+              phase === PHASE_PRODUCTION_SERVER ? CONTENT_SECURITY_POLICY : "",
           },
         ],
       },

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
+const { PHASE_PRODUCTION_SERVER } = require("next/constants")
 const { i18n } = require("./next-i18next.config")
 
-module.exports = {
+module.exports = (phase) => ({
   i18n,
   images: {
     loader: "custom",
@@ -36,8 +37,25 @@ module.exports = {
             key: "X-Content-Type-Options",
             value: "nosniff",
           },
+          {
+            key: "Content-Security-Policy",
+            value:
+              /**
+               * For testing adjustments use https://addons.mozilla.org/en-GB/firefox/addon/laboratory-by-mozilla/
+               * (which allows you to overwrite the Content Security Policy of a particular website).
+               *
+               * Do not add `unsafe-inline` to `script-src`, as we are using dangerouslySetInnerHTML in a few places,
+               * which makes us vulnerable to arbitrary code execution if we receive unsanitized data from the APIs.
+               *
+               * For the development environment we either need to maintain a separate CSP or disable it altogether.
+               * This is because it makes use of `eval` and other features that we don't want to allow in the production environment.
+               */
+              phase === PHASE_PRODUCTION_SERVER
+                ? "default-src 'none'; script-src 'self' https://webstats.gnome.org; style-src 'self' 'unsafe-inline' https://dl.flathub.org; font-src 'self' https://dl.flathub.org; connect-src 'self' https://flathub.org https://webstats.gnome.org; img-src 'self' https://dl.flathub.org https://webstats.gnome.org data:;"
+                : "",
+          },
         ],
       },
     ]
   },
-}
+})


### PR DESCRIPTION
Infer the current rules from https://beta.flathub.org and inscribe them in the policy. From my testing using Laboratory (Content Security Policy / CSP Toolkit) everything seems to work just fine.

The only caveat is that one inline script is blocked (`Content Security Policy: The page's settings blocked the loading of a resource at data:text/javascript;base64,IWZ1bmN0aW9u… ("script-src").`). This script is injected by the `next-themes` package, and the only way to make it run is to add `data:` to `script-src`, which is a trade-off that I don't think it's worth it, especially since the theme switching seems to work just fine without this script. Note that in the next version of the package we should be able to add a hash exception for this script: https://github.com/pacocoursey/next-themes/issues/106, which is a much better trade-off.

Note that I haven't tested being authenticated and anything payment related, so a few adjustments might be necessary.

The CSP string might not be very readable, but it's easy to test by copy-pasting it into Laboratory (Content Security Policy / CSP Toolkit) and similar tools, so I've left it like that (instead of storing it into an object and stringifying it later).