### PR TITLE
Add update tokens

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,6 +40,7 @@ class Settings(BaseSettings):
     stripe_public_key: Optional[str] = None
     stripe_webhook_key: Optional[str] = None
     flat_manager_secret: str = "c2VjcmV0"
+    update_token_secret: str = "c2VjcmV0"
 
 
 settings = Settings()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -428,10 +428,10 @@ class UserOwnedApp(Base):
     created = Column(DateTime, nullable=False)
 
     @staticmethod
-    def user_owns_app(db, user: FlathubUser, app_id: str):
+    def user_owns_app(db, user_id: int, app_id: str):
         return (
             db.session.query(UserOwnedApp)
-            .filter_by(account=user.id, app_id=app_id)
+            .filter_by(account=user_id, app_id=app_id)
             .first()
             is not None
         )

--- a/backend/app/purchases.py
+++ b/backend/app/purchases.py
@@ -1,0 +1,166 @@
+import base64
+from datetime import datetime, timedelta
+from typing import List
+from uuid import uuid4
+
+import jwt
+from fastapi import APIRouter, Body, Depends, FastAPI
+from fastapi.responses import JSONResponse
+from fastapi_sqlalchemy import db as sqldb
+
+from . import config, logins, models
+
+router = APIRouter(prefix="/purchases")
+
+
+@router.post("/generate-update-token", status_code=200)
+def get_update_token(login=Depends(logins.login_state)):
+    """
+    Generates an update token for a user account. This token allows the user to generate download tokens for apps they
+    already own, but does not grant permission to do anything else. By storing this token, flathub-authenticator is
+    able to update apps without user interaction.
+    """
+
+    if not login["state"].logged_in():
+        return JSONResponse({"detail": "not_logged_in"}, status_code=401)
+    user = login["user"]
+
+    encoded = jwt.encode(
+        {
+            "token-id": str(uuid4()),
+            "user-id": user.id,
+            "exp": datetime.utcnow() + timedelta(days=180),
+        },
+        base64.b64decode(config.settings.update_token_secret),
+        algorithm="HS256",
+    )
+
+    return {
+        "token": encoded,
+    }
+
+
+def _check_purchases(appids: List[str], user_id: int):
+    def canon_app_id(app_id: str):
+        # For .Locale, .Debug, etc. refs, we only check the base app ID. However, when we generate the token, we still
+        # need to include the suffixed version.
+        auto_suffixes = ["Locale", "Debug"]
+
+        for suffix in auto_suffixes:
+            if app_id.endswith("." + suffix):
+                return app_id.removesuffix("." + suffix)
+        return app_id
+
+    canon_appids = list(set([canon_app_id(app_id) for app_id in appids]))
+
+    unowned = [
+        app_id
+        for app_id in canon_appids
+        if not models.UserOwnedApp.user_owns_app(sqldb, user_id, app_id)
+    ]
+
+    if len(unowned) != 0:
+        return JSONResponse(
+            {
+                "detail": "purchase_necessary",
+                "missing_appids": unowned,
+            },
+            status_code=403,
+        )
+
+
+@router.post("/check-purchases", status_code=200)
+def check_purchases(appids: List[str], login=Depends(logins.login_state)):
+    """
+    Checks whether the logged in user is able to download all of the given app refs.
+
+    App IDs should be in the form of full refs, e.g. "app/org.gnome.Maps/x86_64/stable".
+    """
+
+    if not login["state"].logged_in():
+        return JSONResponse({"detail": "not_logged_in"}, status_code=401)
+
+    # We get full ref names, e.g. app/org.gnome.Maps/x86_64/master, but we just want the app ID part.
+    try:
+        appids = [app_id.split("/")[1] for app_id in appids]
+    except IndexError:
+        return JSONResponse(
+            {
+                "detail": "invalid_app_id",
+            },
+            status_code=400,
+        )
+
+    if error := _check_purchases(appids, login["user"].id):
+        return error
+
+    return JSONResponse({"status": "ok"})
+
+
+@router.post("/generate-download-token", status_code=200)
+def get_download_token(appids: List[str], update_token: str = Body(None)):
+    """
+    Generates a download token for the given app IDs. App IDs should be in the form of full refs, e.g.
+    "app/org.gnome.Maps/x86_64/stable".
+    """
+
+    try:
+        claims = jwt.decode(
+            update_token,
+            base64.b64decode(config.settings.update_token_secret),
+            algorithms=["HS256"],
+        )
+    except jwt.PyJWTError:
+        return JSONResponse(
+            {
+                "detail": "invalid_token",
+            },
+            status_code=401,
+        )
+
+    try:
+        appids = [app_id.split("/")[1] for app_id in appids]
+    except IndexError:
+        return JSONResponse(
+            {
+                "detail": "invalid_app_id",
+            },
+            status_code=400,
+        )
+
+    if error := _check_purchases(appids, claims["user-id"]):
+        return error
+
+    encoded = jwt.encode(
+        {
+            "sub": "download",
+            "exp": datetime.utcnow() + timedelta(hours=24),
+            "repos": appids,
+        },
+        base64.b64decode(config.settings.flat_manager_secret),
+        algorithm="HS256",
+    )
+
+    # Generate a new update token so the client can continue updating apps non-interactively.
+    new_update_token = jwt.encode(
+        {
+            # re-use the token id, just set a new expiration date
+            "token-id": claims["token-id"],
+            "user-id": claims["user-id"],
+            "exp": datetime.utcnow() + timedelta(days=180),
+        },
+        base64.b64decode(config.settings.update_token_secret),
+        algorithm="HS256",
+    )
+
+    return {
+        "token": encoded,
+        "update-token": new_update_token,
+    }
+
+
+def register_to_app(app: FastAPI):
+    """
+    Register the login and authentication flows with the FastAPI application
+    """
+    app.include_router(router)

--- a/frontend/pages/purchase/checkout.tsx
+++ b/frontend/pages/purchase/checkout.tsx
@@ -2,7 +2,6 @@ import { GetStaticProps } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NextSeo } from "next-seo"
-import Main from "../../src/components/layout/Main"
 import { usePendingTransaction } from "../../src/hooks/usePendingTransaction"
 
 export default function Purchase() {
@@ -10,12 +9,12 @@ export default function Purchase() {
   const [pendingTransaction, _setPendingTransaction] = usePendingTransaction()
 
   return (
-    <Main>
+    <>
       <NextSeo title={t("checkout")} noindex={true} />
       <div className="main-container">
         <h1>{t("checkout")}</h1>
       </div>
-    </Main>
+    </>
   )
 }
 

--- a/frontend/pages/purchase/finished.tsx
+++ b/frontend/pages/purchase/finished.tsx
@@ -2,19 +2,18 @@ import { GetStaticProps } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NextSeo } from "next-seo"
-import Main from "../../src/components/layout/Main"
 
 export default function Purchase() {
   const { t } = useTranslation()
 
   return (
-    <Main>
+    <>
       <NextSeo title={t("thank-you-for-your-purchase")} noindex={true} />
       <div className="main-container">
         <h1>{t("thank-you-for-your-purchase")}</h1>
         {t("safe-to-close-page")}
       </div>
-    </Main>
+    </>
   )
 }
 

--- a/frontend/src/asyncs/app.ts
+++ b/frontend/src/asyncs/app.ts
@@ -1,16 +1,32 @@
-import { TOKEN_GENERATION_URL } from "../env"
+import { CHECK_PURCHASES_URL, TOKEN_GENERATION_URL } from "../env"
 
 /**
- * Generates a token to download a set of apps.
- * @param appids A list of app IDs to generate tokens for
+ * Checks whether the logged in user owns all of the given apps.
+ * @param appids A list of app IDs to check
  */
-export async function generateTokens(appids: string[]) {
+export async function checkPurchases(appids: string[]) {
   try {
-    let res = await fetch(TOKEN_GENERATION_URL, {
+    let res = await fetch(CHECK_PURCHASES_URL, {
       method: "POST",
       credentials: "include",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(appids),
+    })
+
+    return await res.json()
+  } catch {
+    throw "network-error-try-again"
+  }
+}
+
+/**
+ * Generates an update token for the logged in user.
+ */
+export async function generateUpdateToken() {
+  try {
+    let res = await fetch(TOKEN_GENERATION_URL, {
+      method: "POST",
+      credentials: "include",
     })
 
     return await res.json()

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -38,7 +38,8 @@ export const LOGIN_PROVIDERS_URL: string = `${BASE_URI}/auth/login`
 export const USER_INFO_URL: string = `${BASE_URI}/auth/userinfo`
 export const LOGOUT_URL: string = `${BASE_URI}/auth/logout`
 export const USER_DELETION_URL: string = `${BASE_URI}/auth/deleteuser`
-export const TOKEN_GENERATION_URL: string = `${BASE_URI}/generate-download-token`
+export const CHECK_PURCHASES_URL: string = `${BASE_URI}/purchases/check-purchases`
+export const TOKEN_GENERATION_URL: string = `${BASE_URI}/purchases/generate-update-token`
 
 export const WALLET_BASE_URL: string = `${BASE_URI}/wallet`
 export const REMOVE_CARD_URL: string = `${WALLET_BASE_URL}/removecard`


### PR DESCRIPTION
Update tokens can be stored client-side and allow for non-interactive app updates.

Instead of directly logging in and requesting a download token, you log in to get an update token for your account, then use the update token to request download tokens. That way, the update token can be stored client-side, avoiding the need for a webflow login to update already purchased apps.