### PR TITLE
feat(frontend): add back button during checkout

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -179,6 +179,7 @@
   "type": "Type",
   "updated": "Updated",
   "use-new-card": "Use a new card",
+  "use-saved-card": "Use a saved card",
   "value": "Value",
   "view": "View",
   "stripe-api-error": "The Stripe API encountered an error. Try again later.",

--- a/frontend/src/components/payment/checkout/Checkout.tsx
+++ b/frontend/src/components/payment/checkout/Checkout.tsx
@@ -70,6 +70,8 @@ const Checkout: FunctionComponent<Props> = ({ transaction, clientSecret }) => {
         <PaymentForm
           transactionId={transactionId}
           callbackPage={`${detailsPage}/${transactionId}`}
+          canGoBack={cards.length > 0}
+          goBack={() => setStage(Stage.CardSelect)}
         />
       )
       break

--- a/frontend/src/components/payment/checkout/PaymentForm.module.scss
+++ b/frontend/src/components/payment/checkout/PaymentForm.module.scss
@@ -4,4 +4,9 @@
 
   padding: 20px;
   gap: 10px;
+
+  .actions {
+    display: flex;
+    gap: 12px;
+  }
 }

--- a/frontend/src/components/payment/checkout/PaymentForm.tsx
+++ b/frontend/src/components/payment/checkout/PaymentForm.tsx
@@ -14,11 +14,15 @@ import { handleStripeError } from "./stripe"
 interface Props {
   transactionId: string
   callbackPage: string
+  canGoBack: boolean
+  goBack: () => void
 }
 
 const PaymentForm: FunctionComponent<Props> = ({
   transactionId,
   callbackPage,
+  canGoBack,
+  goBack,
 }) => {
   const { t } = useTranslation()
   const stripe = useStripe()
@@ -44,7 +48,12 @@ const PaymentForm: FunctionComponent<Props> = ({
             />
             <label htmlFor="save-card">{t("save-card-for-reuse")}</label>
           </div>
-          <Button>{t("submit-payment")}</Button>
+          <div className={styles.actions}>
+            <Button type="button" onClick={goBack} disabled={!canGoBack}>
+              {t("use-saved-card")}
+            </Button>
+            <Button>{t("submit-payment")}</Button>
+          </div>
         </>
       )}
     </form>


### PR DESCRIPTION
User may want to return to card selection if they change their mind or
accidentally click the button to use a new card.

I first tried this as a button in the Checkout module itself, below the
current stage of the flow. However, it feels too disconnected from the
current stage shown (unlike the cancel button which is independent of
the flow).

closes #134