### PR TITLE
feat(frontend): make content security policy more strict

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -2,12 +2,15 @@ const { PHASE_PRODUCTION_BUILD } = require("next/constants")
 const { i18n } = require("./next-i18next.config")
 
 const CONTENT_SECURITY_POLICY = `
+  base-uri 'self';
   default-src 'none';
+  form-action 'none';
   script-src 'self' https://webstats.gnome.org;
   style-src 'self' 'unsafe-inline' https://dl.flathub.org;
   font-src 'self' https://dl.flathub.org;
   connect-src 'self' https://flathub.org https://webstats.gnome.org;
   img-src 'self' https://dl.flathub.org https://webstats.gnome.org https://avatars.githubusercontent.com https://lh3.googleusercontent.com https://secure.gravatar.com data:;
+  frame-ancestors 'none';
 `
   .replace(/\s{2,}/g, " ")
   .trim()


### PR DESCRIPTION
Implement 3 of the 4 recommendations listed at https://observatory.mozilla.org/analyze/beta.flathub.org:
 - `base-uri 'self'` - there is no use-case for allowing other values
 - `form-action 'none'` - from what I can tell we don't submit native forms at all (instead we intercept the `submit` event and make XHR requests, with are covered by `connect-src`), so we can disallow all HTML form submissions
 - `frame-ancestors 'none'` - don't allow embedding as an iframe (same as `X-Frame-Options: Deny`)