### PR TITLE
feat(frontend): add referrer policy header

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -49,6 +49,10 @@ module.exports = (phase) => ({
             value: "nosniff",
           },
           {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
             key: "Content-Security-Policy",
             value:
               /**


### PR DESCRIPTION
From https://infosec.mozilla.org/guidelines/web_security#referrer-policy:

> `strict-origin-when-cross-origin` send full referrer on same origin, URL without the path on foreign origin

This will prevent accidentally leaking user information from the URL to 3rd parties (e.g. if we ever create a path like `/user/:id`, 3rd parties shouldn't get the id in the header, but only `https://beta.flathub.org`).