### PR TITLE
feat(frontend): add destructive button variant

### DIFF
--- a/frontend/src/components/Button.module.scss
+++ b/frontend/src/components/Button.module.scss
@@ -1,5 +1,6 @@
 .primaryButton,
-.secondaryButton {
+.secondaryButton,
+.destructiveButton {
   background-color: var(--color-primary);
   color: var(--white-10);
   border: none;
@@ -37,6 +38,28 @@
   &:hover:not(:disabled) {
     cursor: pointer;
     background-color: var(--color-primary);
+    color: var(--white-10);
+  }
+
+  &:active:not(:disabled) {
+    background-color: var(--bg-color-primary);
+  }
+
+  &:disabled {
+    color: var(--white-10);
+    border: none;
+  }
+}
+
+.destructiveButton {
+  background-color: var(--bg-color-secondary);
+  color: var(--color-danger);
+  background-image: unset;
+  border: 1px solid var(--color-danger);
+
+  &:hover:not(:disabled) {
+    cursor: pointer;
+    background-color: var(--color-danger);
     color: var(--white-10);
   }
 

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -8,23 +8,23 @@ import styles from "./Button.module.scss"
 
 type Props = {
   children: React.ReactNode
-  variant?: "primary" | "secondary"
+  variant?: "primary" | "secondary" | "destructive"
 } & DetailedHTMLProps<
   ButtonHTMLAttributes<HTMLButtonElement>,
   HTMLButtonElement
 >
 
 const Button: FunctionComponent<Props> = forwardRef<HTMLButtonElement, Props>(
-  ({ children, variant, className, ...buttonProps }, ref) => {
+  ({ children, variant = "primary", className, ...buttonProps }, ref) => {
+    const variantClass = {
+      destructive: styles.destructiveButton,
+      secondary: styles.secondaryButton,
+      primary: styles.primaryButton,
+    }[variant]
+
     return (
       <button
-        className={
-          (variant === "secondary"
-            ? styles.secondaryButton
-            : styles.primaryButton) +
-            " " +
-            className ?? ""
-        }
+        className={`${variantClass} ${className ?? ""}`}
         type={buttonProps.type}
         ref={ref}
         {...buttonProps}

--- a/frontend/src/components/payment/cards/DeleteCardButton.tsx
+++ b/frontend/src/components/payment/cards/DeleteCardButton.tsx
@@ -54,7 +54,7 @@ const DeleteCardButton: FunctionComponent<Props> = ({ card, onSuccess }) => {
           <MdCancel className={styles.mdButton} />
         </Button>
         <Button
-          variant="secondary"
+          variant="destructive"
           onClick={execute}
           aria-label={t("delete")}
           title={t("delete")}

--- a/frontend/src/components/user/DeleteButton.tsx
+++ b/frontend/src/components/user/DeleteButton.tsx
@@ -55,7 +55,7 @@ const DeleteButton: FunctionComponent = () => {
   }
 
   return (
-    <Button onClick={execute} variant="secondary">
+    <Button onClick={execute} variant="destructive">
       {t("delete-account")}
     </Button>
   )

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -9,6 +9,7 @@
 
   --color-primary: hsl(212.9, 58.1%, 55.1%);
   --color-secondary: hsl(195.4, 100%, 44.3%);
+  --color-danger: hsl(0, 100%, 44.3%);
 
   --color-highlight: rgba(0, 0, 0, 0.1);
 


### PR DESCRIPTION
- Styles a button red to indicate a destructive action.
- Used for account deletion and saved card deletion.

Default state:
![Screenshot from 2022-05-16 10-53-45](https://user-images.githubusercontent.com/5459452/168567802-ec2ebbef-3799-4e7d-9b34-d8a2856d4796.png)

On hover:
![Screenshot from 2022-05-16 10-53-48](https://user-images.githubusercontent.com/5459452/168567827-de28b20d-a044-4ab5-8797-8c1434c38d22.png)

Card deletion:
![Screenshot from 2022-05-16 10-54-35](https://user-images.githubusercontent.com/5459452/168567874-de36bad5-da3c-4712-8fcc-5065643b555b.png)


Part of #94
