### PR TITLE
Fix Apps which has no releases

### DIFF
--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -223,9 +223,11 @@ const Details: FunctionComponent<Props> = ({
             />
           </div>
 
-          <Releases
-            latestRelease={app.releases ? app.releases[0] : null}
-          ></Releases>
+          {app.releases && (
+            <Releases
+              latestRelease={app.releases ? app.releases[0] : null}
+            ></Releases>
+          )}
 
           <AdditionalInfo
             data={app}


### PR DESCRIPTION
Some Apps e.g. org.yuzu_emu.yuzu has no releases, which results in a fronted error. This PR fixes this by not displaying the releases section if there is no release.