### PR TITLE
Show full release Date on hover

### DIFF
--- a/frontend/src/components/application/Releases.tsx
+++ b/frontend/src/components/application/Releases.tsx
@@ -42,7 +42,14 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
                     "version-number": latestRelease.version,
                   })}
                 </h3>
-                <div>
+                <div
+                  title={
+                    latestRelease.timestamp &&
+                    new Date(
+                      latestRelease.timestamp * 1000,
+                    ).toLocaleDateString()
+                  }
+                >
                   {latestRelease.timestamp &&
                     formatDistance(
                       new Date(latestRelease.timestamp * 1000),


### PR DESCRIPTION
The releases shows the Date currently as xy ago. With this PR, you see also the real Date if you hover with the Mouse over the xy ago text.