### PR TITLE
Add Permissions

### DIFF
--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -20,6 +20,7 @@ import Lightbox from "react-image-lightbox"
 import ApplicationSection from "./ApplicationSection"
 import LogoImage from "../LogoImage"
 import { calculateHumanReadableSize } from "../../size"
+import Permissions from "./Permissions"
 
 import "react-image-lightbox/style.css" // This only needs to be imported once in your app
 
@@ -235,6 +236,8 @@ const Details: FunctionComponent<Props> = ({
             appId={app.id}
             stats={stats}
           ></AdditionalInfo>
+
+          <Permissions summary={summary} appId={app.id}></Permissions>
 
           {developerApps && developerApps.length > 0 && (
             <ApplicationSection

--- a/frontend/src/components/application/Permissions.tsx
+++ b/frontend/src/components/application/Permissions.tsx
@@ -1,0 +1,86 @@
+import { Summary } from "../../types/Summary"
+import ListBox from "./ListBox"
+import styles from "./AdditionalInfo.module.scss"
+import { MdWifi, MdChatBubble, MdDevices } from "react-icons/md"
+import { i18n, useTranslation } from "next-i18next"
+import { TFunction } from "react-i18next"
+
+const Permissions = ({
+  summary,
+  appId,
+}: {
+  summary?: Summary
+  appId: string
+}) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className={styles.additionalInfo}>
+      {summary.metadata.permissions.shared.indexOf("network") != -1 && (
+        <ListBox
+          appId={appId}
+          items={[
+            {
+              icon: <MdWifi />,
+              header: "Network",
+              content: {
+                type: "text",
+                text: "This App has network access",
+              },
+            },
+          ]}
+        ></ListBox>
+      )}
+
+      {summary.metadata.permissions.sockets.indexOf("session-bus") != -1 && (
+        <ListBox
+          appId={appId}
+          items={[
+            {
+              icon: <MdChatBubble />,
+              header: "Session Bus",
+              content: {
+                type: "text",
+                text: "This App has full access to the entire session bus",
+              },
+            },
+          ]}
+        ></ListBox>
+      )}
+
+      {summary.metadata.permissions.sockets.indexOf("system-bus") != -1 && (
+        <ListBox
+          appId={appId}
+          items={[
+            {
+              icon: <MdChatBubble />,
+              header: "System Bus",
+              content: {
+                type: "text",
+                text: "This App has full access to the entire system bus",
+              },
+            },
+          ]}
+        ></ListBox>
+      )}
+
+      {summary.metadata.permissions.devices.indexOf("all") != -1 && (
+        <ListBox
+          appId={appId}
+          items={[
+            {
+              icon: <MdDevices />,
+              header: "All devices",
+              content: {
+                type: "text",
+                text: "This App has full access to all devices",
+              },
+            },
+          ]}
+        ></ListBox>
+      )}
+    </div>
+  )
+}
+
+export default Permissions


### PR DESCRIPTION
This PR adds Permissions to the Apppage. It is currently only a proof of concept to see what the reactions are before going any further. It displays only 4 permissions at the time. Translations are also not included yet. If the maintainers are OK with this, I will add more Permissions.

There are also open Questions:
1. How should we display filesystem access? Should we only show a Card with home, host or with every single folder e.g. --filesystem=~/.myapp?
2. How should we handle D-Bus permissions? If a App has the Permission to talk with org.freedesktop.notifications, is that not interesting. If a App however has the Permission to talk with org.freedesktop.flatpak, this is far more interesting.

![grafik](https://user-images.githubusercontent.com/15185051/169018980-95cfbb06-3ae5-4a74-90eb-efc793c5ce96.png)
