### PR TITLE
refactor(frontend): remove excess main containers

### DIFF
--- a/frontend/pages/userpage.module.scss
+++ b/frontend/pages/userpage.module.scss
@@ -1,7 +1,0 @@
-.userArea {
-  display: flex;
-  flex-direction: column;
-  row-gap: 15px;
-
-  padding: 10px;
-}

--- a/frontend/pages/userpage.tsx
+++ b/frontend/pages/userpage.tsx
@@ -7,7 +7,6 @@ import UserDetails from "../src/components/user/Details"
 import UserApps from "../src/components/user/UserApps"
 import { fetchLoginProviders } from "../src/fetchers"
 import { LoginProvider } from "../src/types/Login"
-import styles from "./userpage.module.scss"
 
 export default function Userpage({ providers }) {
   const { t } = useTranslation()
@@ -16,7 +15,7 @@ export default function Userpage({ providers }) {
   return (
     <>
       <NextSeo title={t("user-page")} noindex={true} />
-      <div className={styles.userArea}>
+      <div className="main-container" style={{ marginTop: "20px" }}>
         <LoginGuard>
           <UserDetails logins={providers} />
           <UserApps />

--- a/frontend/src/components/payment/cards/SavedCards.tsx
+++ b/frontend/src/components/payment/cards/SavedCards.tsx
@@ -53,10 +53,10 @@ const SavedCards: FunctionComponent = () => {
   }
 
   return (
-    <div className="main-container">
+    <>
       <h3>{t("saved-cards")}</h3>
       {content}
-    </div>
+    </>
   )
 }
 

--- a/frontend/src/components/payment/checkout/CardSelect.tsx
+++ b/frontend/src/components/payment/checkout/CardSelect.tsx
@@ -95,7 +95,7 @@ const CardSelect: FunctionComponent<Props> = ({
   // Should always present the option to use a new card in case user
   // doesn't want to wait for a slow network
   return (
-    <div className="main-container">
+    <div>
       <h3>{t("saved-cards")}</h3>
       {cardSection}
       <div style={{ display: "flex", gap: "12px" }}>

--- a/frontend/src/components/payment/checkout/Checkout.tsx
+++ b/frontend/src/components/payment/checkout/Checkout.tsx
@@ -81,15 +81,13 @@ const Checkout: FunctionComponent<Props> = ({ transaction, clientSecret }) => {
   }
 
   return (
-    <div className="main-container">
-      <div className={styles.checkout}>
-        {flowContent}
-        <div className="actions">
-          <TransactionCancelButton
-            id={transactionId}
-            onSuccess={() => router.push(`${detailsPage}/${transactionId}`)}
-          />
-        </div>
+    <div className={styles.checkout}>
+      {flowContent}
+      <div className="actions">
+        <TransactionCancelButton
+          id={transactionId}
+          onSuccess={() => router.push(`${detailsPage}/${transactionId}`)}
+        />
       </div>
     </div>
   )

--- a/frontend/src/components/payment/transactions/TransactionHistory.tsx
+++ b/frontend/src/components/payment/transactions/TransactionHistory.tsx
@@ -63,7 +63,7 @@ const TransactionHistory: FunctionComponent = () => {
   const pageSlice = transactions.slice(page * perPage, page * perPage + perPage)
 
   return (
-    <div className="main-container">
+    <>
       <h3>{t("transaction-history")}</h3>
       {error ? (
         <p>{t(error)}</p>
@@ -90,7 +90,7 @@ const TransactionHistory: FunctionComponent = () => {
           </div>
         </>
       )}
-    </div>
+    </>
   )
 
   function pageForward() {

--- a/frontend/src/components/user/Details.tsx
+++ b/frontend/src/components/user/Details.tsx
@@ -65,33 +65,31 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
   )
 
   return (
-    <div className="main-container">
-      <div className={styles.details}>
-        <h2 className={styles.displayname}>{user.info.displayname}</h2>
+    <div className={styles.details}>
+      <h2 className={styles.displayname}>{user.info.displayname}</h2>
 
+      <div className={styles.subsection}>
+        <h3>{t("linked-accounts")}</h3>
+        <div className={styles.authList}>{linkedAccounts}</div>
+      </div>
+
+      {loginSection}
+
+      {user.info["dev-flatpaks"].length ? (
         <div className={styles.subsection}>
-          <h3>{t("linked-accounts")}</h3>
-          <div className={styles.authList}>{linkedAccounts}</div>
+          <h3>{t("accepting-payment")}</h3>
+          <VendingLink />
         </div>
+      ) : (
+        <></>
+      )}
 
-        {loginSection}
-
-        {user.info["dev-flatpaks"].length ? (
-          <div className={styles.subsection}>
-            <h3>{t("accepting-payment")}</h3>
-            <VendingLink />
-          </div>
-        ) : (
-          <></>
-        )}
-
-        <div className={styles.actions}>
-          <Link href="/wallet" passHref>
-            <Button variant="primary">{t("view-wallet")}</Button>
-          </Link>
-          <LogoutButton />
-          <DeleteButton />
-        </div>
+      <div className={styles.actions}>
+        <Link href="/wallet" passHref>
+          <Button variant="primary">{t("view-wallet")}</Button>
+        </Link>
+        <LogoutButton />
+        <DeleteButton />
       </div>
     </div>
   )


### PR DESCRIPTION
Returning a `"main-container"` div within components results in various superfluous containing divs in the final DOM.

If this div is common to every page we should probably insert it at a single point like we do with `main`.