### PR TITLE
docs: add Stripe dev and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Then you should be able to start the dev server and see changed to the code:
 yarn dev
 ```
 
-
 ## More backend instructions
 
 You can find more backend instructions in the readme in the backend folder.
@@ -54,3 +53,27 @@ You can find more backend instructions in the readme in the backend folder.
 
 We're using [Weblate](https://hosted.weblate.org/engage/flathub/) to translate the UI. So feel free, to contribute translations over there.
 
+## Stripe development setup
+
+In development, to connect the backend to Stripe you must:
+
+1. Create a US based Stripe account and verify your email.
+2. Go to the Developers tab of the Stripe dashboard and toggle test mode.
+3. Insert the publishable and secret keys from the page into the corresponding backend `docker-compose.yml` environment variables (`STRIPE_PUBLIC_KEY` and `STRIPE_SECRET_KEY`).
+4. Go the the Webhooks section of the Developers tab, select to test in a local environment.
+5. Follow the steps to setup the webhook with Stripe CLI, listening to `localhost:8000/wallet/webhook/stripe`.
+6. Insert the webhook signing secret into the corresponding backend `docker-compose.yml` environment variable (`STRIPE_WEBHOOK_KEY`).
+
+To allow creation of test Stripe Express accounts, you must:
+
+1. Go to the Connect tab of the Stripe dashboard.
+2. Complete the platform profile.
+3. Go to Settings > Connect Settings in your Stripe account and set a business name and icon.
+
+## Stripe testing
+
+In both staging and development environments, Stripe is running in test mode (all data is fake).
+
+To test payment, card details can be used from https://stripe.com/docs/testing
+
+To test creation of a Stripe Express account, see https://stripe.com/docs/connect/testing


### PR DESCRIPTION
This should be of use to those testing out beta.flathub.org as well as for quick reference while developing