### PR TITLE
fix(frontend): remove extra footer column

### DIFF
--- a/frontend/src/components/layout/Footer.module.scss
+++ b/frontend/src/components/layout/Footer.module.scss
@@ -8,7 +8,7 @@
     margin-left: auto;
     margin-right: auto;
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     gap: 0px 0px;
     justify-items: center;
     max-width: 900px;


### PR DESCRIPTION
Left over from when login was in the footer, just causes a very slight misalignment because of the extra empty column