### PR TITLE
fix(frontend): add next-themes script hash to script-src

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -6,7 +6,7 @@ const CONTENT_SECURITY_POLICY = `
   prefetch-src 'self' ${process.env.NEXT_PUBLIC_SITE_BASE_URI};
   default-src 'none';
   form-action 'none';
-  script-src 'self' https://webstats.gnome.org;
+  script-src 'self' 'sha256-fDVtD703YIdPFRhb6ZJE/SvcwyA7gZRWfRRM6K6r9EA=' https://webstats.gnome.org;
   style-src 'self' 'unsafe-inline' https://dl.flathub.org;
   font-src 'self' https://dl.flathub.org;
   connect-src 'self' https://flathub.org https://webstats.gnome.org;


### PR DESCRIPTION
Apply the suggested fix from https://github.com/pacocoursey/next-themes/issues/106#issuecomment-1122012509. The only downside is that if the script changes when the dependency is upgraded, the hash would need to be updated accordingly.

Closes https://github.com/flathub/website/issues/298.