### PR TITLE
fix: remove bad status console error if logged out

### DIFF
--- a/backend/app/logins.py
+++ b/backend/app/logins.py
@@ -739,7 +739,7 @@ def continue_oauth_flow(
 def get_userinfo(login=Depends(login_state)):
     """
     Retrieve the current login's user information.  If the user is not logged in
-    you will get a `403` return.  Otherwise you will receive JSON describing the
+    you will get a `204` return.  Otherwise you will receive JSON describing the
     currently logged in user, for example:
 
     ```
@@ -756,7 +756,7 @@ def get_userinfo(login=Depends(login_state)):
     dev-flatpaks is filtered against IDs available in AppStream
     """
     if not login["state"].logged_in():
-        return Response(status_code=403)
+        return Response(status_code=204)
     user = login["user"]
     ret = {"displayname": user.display_name, "dev-flatpaks": set()}
     ret["auths"] = {}

--- a/frontend/src/asyncs/login.ts
+++ b/frontend/src/asyncs/login.ts
@@ -80,14 +80,18 @@ export async function getUserData(
 
   // Assuming a bad status indicates unchanged user state
   if (res.ok) {
-    const info: UserInfo = await res.json()
-    dispatch({
-      type: "login",
-      info,
-    })
+    // A no content status response indicates the user is not logged in
+    if (res.status === 204) {
+      dispatch({ type: "logout" })
+    } else {
+      const info: UserInfo = await res.json()
+      dispatch({
+        type: "login",
+        info,
+      })
+    }
   } else {
-    // 403 specifically indicates not currently logged in
-    dispatch({ type: res.status === 403 ? "logout" : "interrupt" })
+    dispatch({ type: "interrupt" })
   }
 }
 


### PR DESCRIPTION
A status 204 seems more appropriate to tell the client the request was
successful, but there is no content to return (i.e. no user data when
logged out).

If we explicitly want to discourage use of this endpoint while logged
out we could leave it as 403 and instead work in some client-side user
context persistence with local storage. That's probably not worth the
hassle at this time.

fixes #296