### PR TITLE
Use long format for date(time) strings

### DIFF
--- a/frontend/src/components/application/Releases.tsx
+++ b/frontend/src/components/application/Releases.tsx
@@ -55,6 +55,7 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
                     latestRelease.timestamp &&
                     new Date(latestRelease.timestamp * 1000).toLocaleDateString(
                       i18n.language.substring(0, 2),
+                      { dateStyle: 'long' },
                     )
                   }
                 >

--- a/frontend/src/components/payment/transactions/TransactionSummary.tsx
+++ b/frontend/src/components/payment/transactions/TransactionSummary.tsx
@@ -13,9 +13,11 @@ const TransactionSummary: FunctionComponent<Props> = ({ transaction }) => {
 
   const prettyCreated = new Date(created * 1000).toLocaleString(
     i18n.language.substring(0, 2),
+    { dateStyle: 'long' },
   )
   const prettyUpdated = new Date(updated * 1000).toLocaleString(
     i18n.language.substring(0, 2),
+    { dateStyle: 'long' },
   )
   const prettyValue = new Intl.NumberFormat(i18n.language.substring(0, 2), {
     style: "currency",


### PR DESCRIPTION
Currently all regional variations of any given language are ignored:
UK and US English are treated as one language.

Sadly the numerical date format is different between the US (m/d/y) and
most of the rest of the anglosphere (d/m/y), and ambiguously so.

Use the "long" format for formatted dates. 'June 5, 2022' may not be the
way yesterday's date would be written in the UK, but unlike '6/5/2022'
it doesn't read as '6th May 2022'.

Fixes #329
