### PR TITLE
Show Link in Release section

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -43,6 +43,7 @@
   "contribute": "Contribute to the App",
   "no-changelog-provided": "No changelog provided",
   "changes-in-version": "Changes in version {{version-number}}",
+  "release-link": "Get more Information",
   "manual-install": "Manual Install",
   "run": "Run",
   "copy-text": "Copy Text",

--- a/frontend/src/components/application/Releases.tsx
+++ b/frontend/src/components/application/Releases.tsx
@@ -32,10 +32,19 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
     [t],
   )
 
-  const releaseDescription = useMemo(
+  var releaseDescription = useMemo(
     () => (latestRelease.description ? latestRelease.description : noChangelog),
     [latestRelease.description, noChangelog],
   )
+
+  if (latestRelease.url) {
+    releaseDescription +=
+      "<a href='" +
+      latestRelease.url +
+      "' class='list-disc my-4 pl-10'>" +
+      t("release-link") +
+      "</a>"
+  }
 
   return (
     <>

--- a/frontend/src/components/application/Releases.tsx
+++ b/frontend/src/components/application/Releases.tsx
@@ -41,7 +41,7 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
     releaseDescription +=
       "<a href='" +
       latestRelease.url +
-      "' class='list-disc my-4 pl-10'>" +
+      "' class='list-disc my-4 pl-10' target='_blank' rel='noreferrer'>" +
       t("release-link") +
       "</a>"
   }

--- a/frontend/src/types/Appstream.ts
+++ b/frontend/src/types/Appstream.ts
@@ -96,6 +96,7 @@ export interface Release {
   description?: string
   timestamp?: number
   version: string
+  url?: string
 }
 
 export interface Launchable {


### PR DESCRIPTION
Programs can provide a Link to more Informations in the Release section of Appstream. This is used e.g. by Inkscape to link to a Wiki page with a more detailed changelog. This PR adds this Link to the Website.

![grafik](https://user-images.githubusercontent.com/15185051/172793897-5a25d223-16da-43a1-a288-d04c2def7e09.png)
