### PR TITLE
ci: Drop distributhor/workflow-webhook

### DIFF
--- a/.github/workflows/backend_deploy.yml
+++ b/.github/workflows/backend_deploy.yml
@@ -43,9 +43,3 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Trigger a deployment
-        uses: distributhor/workflow-webhook@6edfd7cdaf8e0551b717bab8912c8d910475b98f
-        env:
-          webhook_url: ${{ secrets.DEPLOY_WEBHOOK_ENDPOINT }}
-          webhook_secret: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}

--- a/.github/workflows/frontend_deploy.yml
+++ b/.github/workflows/frontend_deploy.yml
@@ -43,9 +43,3 @@ jobs:
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      - name: Trigger a deployment
-        uses: distributhor/workflow-webhook@58116e2659a0aeab1893a68f0f2638d665296527
-        env:
-          webhook_url: ${{ secrets.DEPLOY_WEBHOOK_ENDPOINT }}
-          webhook_secret: ${{ secrets.DEPLOY_WEBHOOK_SECRET }}


### PR DESCRIPTION
OpenShift will eventually detect that a new image has been pushed
to GHCR and trigger a new deployment automatically.