### PR TITLE
feat(frontend): use modal for deletion confirmation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "format:fix": "prettier --write --ignore-path .gitignore ."
   },
   "dependencies": {
+    "@headlessui/react": "^1.6.4",
     "@jonkoops/matomo-tracker-react": "^0.7.0",
     "@stripe/react-stripe-js": "^1.8.1",
     "@stripe/stripe-js": "^1.29.0",

--- a/frontend/pages/userpage.tsx
+++ b/frontend/pages/userpage.tsx
@@ -4,6 +4,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NextSeo } from "next-seo"
 import LoginGuard from "../src/components/login/LoginGuard"
 import Spinner from "../src/components/Spinner"
+import DeleteButton from "../src/components/user/DeleteButton"
 import UserDetails from "../src/components/user/Details"
 import UserApps from "../src/components/user/UserApps"
 import { fetchLoginProviders } from "../src/fetchers"
@@ -16,10 +17,13 @@ export default function Userpage({ providers }) {
   return (
     <>
       <NextSeo title={t("user-page")} noindex={true} />
-      <div className="flex flex-col gap-y-4 p-3">
+      <div className="max-w-11/12 my-0 mx-auto flex w-11/12 flex-col gap-y-4 p-3 2xl:w-[1400px] 2xl:max-w-[1400px]">
         <LoginGuard>
           <UserDetails logins={providers} />
           <UserApps />
+          <div className="rounded-xl bg-bgColorSecondary p-4 shadow-md">
+            <DeleteButton />
+          </div>
         </LoginGuard>
       </div>
     </>

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -28,7 +28,7 @@ const Button: FunctionComponent<Props> = forwardRef<HTMLButtonElement, Props>(
       <button
         className={`${
           className ?? ""
-        } ${variantClass} no-wrap h-12 whitespace-nowrap rounded-xl px-5 py-2 text-center font-medium duration-500 hover:cursor-pointer active:bg-bgColorPrimary active:text-colorPrimary disabled:cursor-default`}
+        } ${variantClass} no-wrap h-12 overflow-hidden text-ellipsis whitespace-nowrap rounded-xl px-5 py-2 text-center font-medium duration-500 hover:cursor-pointer active:bg-bgColorPrimary active:text-colorPrimary disabled:cursor-default`}
         type={buttonProps.type}
         ref={ref}
         {...buttonProps}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -64,6 +64,15 @@ const ConfirmDialog: FunctionComponent<Props> = ({
             <div className="mt-3 grid grid-cols-2 gap-6">
               <Button
                 className="col-start-1"
+                onClick={() => setCancelled(true)}
+                variant="primary"
+                aria-label={t("cancel")}
+                title={t("cancel")}
+              >
+                {t("cancel")}
+              </Button>
+              <Button
+                className="col-start-2"
                 onClick={() => setConfirmed(true)}
                 variant="primary"
                 aria-label={action}
@@ -71,15 +80,6 @@ const ConfirmDialog: FunctionComponent<Props> = ({
                 disabled={entry && text !== entry}
               >
                 {action}
-              </Button>
-              <Button
-                className="col-start-2"
-                onClick={() => setCancelled(true)}
-                variant="primary"
-                aria-label={t("cancel")}
-                title={t("cancel")}
-              >
-                {t("cancel")}
               </Button>
             </div>
           </Dialog.Panel>

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,8 +1,10 @@
-import { FunctionComponent, useEffect, useState } from "react"
+import { Fragment, FunctionComponent, useEffect, useState } from "react"
 import Button from "./Button"
 import { useTranslation } from "next-i18next"
+import { Dialog, Transition } from "@headlessui/react"
 
 interface Props {
+  isVisible: boolean
   prompt: string
   entry?: string
   action: string
@@ -14,6 +16,7 @@ interface Props {
  * confirmation or cancellation.
  */
 const ConfirmDialog: FunctionComponent<Props> = ({
+  isVisible,
   prompt,
   entry,
   action,
@@ -36,7 +39,9 @@ const ConfirmDialog: FunctionComponent<Props> = ({
 
   const toEnter = (
     <div>
-      <p>{t("entry-confirmation-prompt", { text: entry })}</p>
+      <Dialog.Description>
+        {t("entry-confirmation-prompt", { text: entry })}
+      </Dialog.Description>
       <input
         className="w-full rounded-xl border border-textSecondary p-3"
         value={text}
@@ -45,31 +50,38 @@ const ConfirmDialog: FunctionComponent<Props> = ({
     </div>
   )
 
-  const confirm = (
-    <Button
-      className="col-start-1"
-      onClick={() => setConfirmed(true)}
-      variant="primary"
-    >
-      {action}
-    </Button>
-  )
-
   return (
-    <div className="fixed right-5 top-24 z-20 m-auto flex flex-col justify-center rounded-xl border border-textSecondary bg-bgColorPrimary p-3">
-      <span>{prompt}</span>
-      {entry ? toEnter : <></>}
-      <div className="mt-3 grid grid-cols-2 gap-3">
-        {entry && text === entry ? confirm : <></>}
-        <Button
-          className="col-start-2"
-          onClick={() => setCancelled(true)}
-          variant="primary"
-        >
-          {t("cancel")}
-        </Button>
-      </div>
-    </div>
+    <Transition appear show={isVisible} as={Fragment}>
+      <Dialog as="div" className="z-20 " onClose={() => setCancelled(true)}>
+        <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+
+        <div className="fixed inset-0 flex items-center justify-center p-4">
+          <Dialog.Panel className="inline-flex flex-col justify-center gap-6 rounded-xl bg-bgColorPrimary p-8 shadow-md">
+            <Dialog.Title className="mt-0">{prompt}</Dialog.Title>
+
+            {entry ? toEnter : <></>}
+
+            <div className="mt-3 grid grid-cols-2 gap-6">
+              <Button
+                className="col-start-1"
+                onClick={() => setConfirmed(true)}
+                variant="primary"
+                disabled={entry && text !== entry}
+              >
+                {action}
+              </Button>
+              <Button
+                className="col-start-2"
+                onClick={() => setCancelled(true)}
+                variant="primary"
+              >
+                {t("cancel")}
+              </Button>
+            </div>
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </Transition>
   )
 }
 

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -56,8 +56,8 @@ const ConfirmDialog: FunctionComponent<Props> = ({
         <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
         <div className="fixed inset-0 flex items-center justify-center p-4">
-          <Dialog.Panel className="inline-flex flex-col justify-center gap-6 rounded-xl bg-bgColorPrimary p-8 shadow-md">
-            <Dialog.Title className="mt-0">{prompt}</Dialog.Title>
+          <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-bgColorPrimary p-14 shadow-md">
+            <Dialog.Title className="m-0">{prompt}</Dialog.Title>
 
             {entry ? toEnter : <></>}
 
@@ -66,6 +66,8 @@ const ConfirmDialog: FunctionComponent<Props> = ({
                 className="col-start-1"
                 onClick={() => setConfirmed(true)}
                 variant="primary"
+                aria-label={action}
+                title={action}
                 disabled={entry && text !== entry}
               >
                 {action}
@@ -74,6 +76,8 @@ const ConfirmDialog: FunctionComponent<Props> = ({
                 className="col-start-2"
                 onClick={() => setCancelled(true)}
                 variant="primary"
+                aria-label={t("cancel")}
+                title={t("cancel")}
               >
                 {t("cancel")}
               </Button>

--- a/frontend/src/components/user/DeleteButton.tsx
+++ b/frontend/src/components/user/DeleteButton.tsx
@@ -42,22 +42,21 @@ const DeleteButton: FunctionComponent = () => {
     return <Spinner size="s" />
   }
 
-  if (token) {
-    return (
+  return (
+    <>
+      <Button onClick={execute} variant="destructive">
+        {t("delete-account")}
+      </Button>
+
       <ConfirmDialog
+        isVisible={!!token}
         prompt={t("delete-account-prompt")}
         entry={t("delete-account-entry")}
         action={t("delete-account")}
         onConfirmed={execute}
         onCancelled={() => setToken("")}
       />
-    )
-  }
-
-  return (
-    <Button onClick={execute} variant="destructive">
-      {t("delete-account")}
-    </Button>
+    </>
   )
 }
 

--- a/frontend/src/components/user/Details.tsx
+++ b/frontend/src/components/user/Details.tsx
@@ -67,35 +67,32 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
   )
 
   return (
-    <div className="max-w-11/12 my-0 mx-auto w-11/12 2xl:w-[1400px] 2xl:max-w-[1400px]">
-      <div className="grid rounded-xl bg-bgColorSecondary p-4 text-textPrimary shadow-md">
-        <h2 className="col-start-1 row-start-1 mt-0 mb-3">
-          {user.info.displayname}
-        </h2>
+    <div className="grid rounded-xl bg-bgColorSecondary p-4 text-textPrimary shadow-md">
+      <h2 className="col-start-1 row-start-1 mt-0 mb-3">
+        {user.info.displayname}
+      </h2>
 
+      <div className="mx-4 my-auto">
+        <h3>{t("linked-accounts")}</h3>
+        <div className="flex flex-row flex-wrap gap-3">{linkedAccounts}</div>
+      </div>
+
+      {loginSection}
+
+      {user.info["dev-flatpaks"].length ? (
         <div className="mx-4 my-auto">
-          <h3>{t("linked-accounts")}</h3>
-          <div className="flex flex-row flex-wrap gap-3">{linkedAccounts}</div>
+          <h3>{t("accepting-payment")}</h3>
+          <VendingLink />
         </div>
+      ) : (
+        <></>
+      )}
 
-        {loginSection}
-
-        {user.info["dev-flatpaks"].length ? (
-          <div className="mx-4 my-auto">
-            <h3>{t("accepting-payment")}</h3>
-            <VendingLink />
-          </div>
-        ) : (
-          <></>
-        )}
-
-        <div className="row-start-1 row-end-4 ml-auto flex flex-col gap-2">
-          <Link href="/wallet" passHref>
-            <Button variant="primary">{t("view-wallet")}</Button>
-          </Link>
-          <LogoutButton />
-          <DeleteButton />
-        </div>
+      <div className="row-start-1 row-end-4 ml-auto flex flex-col gap-2">
+        <Link href="/wallet" passHref>
+          <Button variant="primary">{t("view-wallet")}</Button>
+        </Link>
+        <LogoutButton />
       </div>
     </div>
   )

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -37,6 +37,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@headlessui/react@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.6.4.tgz#c73084e23386bef5fb86cd16da3352c3a844bb4c"
+  integrity sha512-0yqz1scwbFtwljmbbKjXsSGl5ABEYNICVHZnMCWo0UtOZodo2Tpu94uOVgCRjRZ77l2WcTi2S0uidINDvG7lsA==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.2"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz"


### PR DESCRIPTION
This PR actually makes the confirmation dialog component use Headless UI's modal component which brings all the benefits of:

- Adding a transition
- Built-in accessibility attributes and navigation
- Inherently using a React portal to render on top of the page and easily centre the dialog

I also moved the account deletion button to the bottom of the user page since it's a one-time action that doesn't contribute to user convenience by being immediately available at the top of the page (and associated with the other actions there).

New deletion button location:
![Screenshot from 2022-06-17 18-39-58](https://user-images.githubusercontent.com/5459452/174350293-bc22eda7-cfaa-4018-85ec-8093d890dd41.png)

Modal dialog in action:
![Screenshot from 2022-06-17 18-40-10](https://user-images.githubusercontent.com/5459452/174350313-cf204359-a1ba-47e7-aa64-e267653af6da.png)

