### PR TITLE
fix(frontend): redirect to stored page on login

### DIFF
--- a/frontend/pages/login/[service].tsx
+++ b/frontend/pages/login/[service].tsx
@@ -3,35 +3,59 @@ import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NextSeo } from "next-seo"
 import { useRouter } from "next/router"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { toast } from "react-toastify"
 import { login } from "../../src/asyncs/login"
 import Spinner from "../../src/components/Spinner"
 import { useUserContext, useUserDispatch } from "../../src/context/user-info"
 import { fetchLoginProviders } from "../../src/fetchers"
+import { useAsync } from "../../src/hooks/useAsync"
 import { useLocalStorage } from "../../src/hooks/useLocalStorage"
 import { usePendingTransaction } from "../../src/hooks/usePendingTransaction"
 import { isInternalRedirect } from "../../src/utils/security"
 
-export default function AuthReturnPage({ services }) {
+export default function AuthReturnPage({ services }: { services: string[] }) {
   // Must access query params to POST to backend for oauth verification
   const { t } = useTranslation()
   const router = useRouter()
 
-  // Send only one request, prevent infinite loops
-  const [sent, setSent] = useState(false)
-
   const user = useUserContext()
   const dispatch = useUserDispatch()
 
-  const [pendingTransaction, _setPendingTransaction] = usePendingTransaction()
+  const [pendingTransaction] = usePendingTransaction()
   const [returnTo, setReturnTo] = useLocalStorage<string>("returnTo", "")
 
+  const { execute, status, error } = useAsync(
+    useCallback(() => login(dispatch, router.query), [dispatch, router.query]),
+    false,
+  )
+
   useEffect(() => {
+    if (error) {
+      toast.error(t(error))
+    }
+  }, [t, error])
+
+  // Once router ready, perform login
+  useEffect(() => {
+    if (router.isReady) {
+      execute()
+    }
+  }, [router.isReady, execute])
+
+  // Prevent mistaken ridirection after stored value is cleared
+  const [redirected, setRedirected] = useState(false)
+
+  useEffect(() => {
+    if (redirected) return
+
     // Redirect back to where user was, or userpage for unprompted login
-    if (user.info && !user.loading) {
+    if (status === "success" && user.info && !user.loading) {
+      setRedirected(true)
+
       if (pendingTransaction) {
         router.push("/purchase")
+        return
       } else if (returnTo) {
         const redirect = decodeURIComponent(returnTo)
         setReturnTo(null)
@@ -39,20 +63,26 @@ export default function AuthReturnPage({ services }) {
         // Must validate the redirect to prevent open redirect and code execution
         if (isInternalRedirect(redirect)) {
           router.push(redirect)
-        } else {
-          router.push("/userpage")
+          return
         }
-      } else {
-        router.push("/userpage")
       }
-    }
 
-    // Router must be ready to access query parameters
-    if (!router.isReady) {
-      return
+      router.push("/userpage")
     }
+  }, [
+    status,
+    user,
+    pendingTransaction,
+    returnTo,
+    router,
+    redirected,
+    setReturnTo,
+  ])
 
-    // Redirect away if user tries some kind of directory traversal
+  // Redirect away if user tries some kind of directory traversal
+  useEffect(() => {
+    if (!router.isReady) return
+
     if (
       services.every((s: string) => s !== router.query.service) ||
       router.query.code == null ||
@@ -61,27 +91,13 @@ export default function AuthReturnPage({ services }) {
       router.push(user.info ? "/userpage" : "/")
       return
     }
+  }, [router, user, services])
 
-    if (!sent) {
-      setSent(true)
-      login(dispatch, router.query).catch((err) => toast.error(t(err)))
-    }
-  }, [
-    router,
-    dispatch,
-    user,
-    sent,
-    services,
-    t,
-    pendingTransaction,
-    returnTo,
-    setReturnTo,
-  ])
-
+  // This is purely a loading page
   return (
     <>
       <NextSeo title={t("login")} noindex={true}></NextSeo>
-      {user.loading ? <Spinner size="l" /> : <></>}
+      <Spinner size="l" />
     </>
   )
 }

--- a/frontend/pages/payment/[transaction_id].tsx
+++ b/frontend/pages/payment/[transaction_id].tsx
@@ -6,6 +6,7 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NextSeo } from "next-seo"
 import { useRouter } from "next/router"
 import { ReactElement, useEffect, useState } from "react"
+import LoginGuard from "../../src/components/login/LoginGuard"
 import Checkout from "../../src/components/payment/checkout/Checkout"
 import RelatedLink from "../../src/components/RelatedLink"
 import Spinner from "../../src/components/Spinner"
@@ -96,23 +97,13 @@ export default function TransactionPage() {
 
   // Once router is ready the transaction ID is attainable
   useEffect(() => {
-    // Must be logged in to make a payment
-    if (!user.info && !user.loading) {
-      router.push("/login")
-    }
-
     // Router must be ready to access query parameters
     if (!router.isReady) {
       return
     }
 
     // Once the transaction ID is known, the client secret is fetched
-    const { transaction_id } = router.query
-
-    // NOTE: Not sure when this will actually happen?
-    if (Array.isArray(transaction_id)) {
-      return
-    }
+    const transaction_id = router.query.transaction_id as string
 
     getTransaction(transaction_id)
       .then(([transaction, secret]) => {
@@ -146,8 +137,10 @@ export default function TransactionPage() {
     <>
       <NextSeo title={t("payment")} noindex={true}></NextSeo>
       <div className="max-w-11/12 my-0 mx-auto w-11/12 2xl:w-[1400px] 2xl:max-w-[1400px]">
-        <RelatedLink href="/wallet" pageTitle={t("user-wallet")} />
-        {content}
+        <LoginGuard>
+          <RelatedLink href="/wallet" pageTitle={t("user-wallet")} />
+          {content}
+        </LoginGuard>
       </div>
     </>
   )

--- a/frontend/pages/payment/details/[transaction_id].tsx
+++ b/frontend/pages/payment/details/[transaction_id].tsx
@@ -13,6 +13,7 @@ import Spinner from "../../../src/components/Spinner"
 import { useUserContext } from "../../../src/context/user-info"
 import { TRANSACTION_INFO_URL } from "../../../src/env"
 import { TransactionDetailed } from "../../../src/types/Payment"
+import LoginGuard from "../../../src/components/login/LoginGuard"
 
 async function getTransaction(transactionId: string) {
   let res: Response
@@ -41,23 +42,13 @@ export default function TransactionPage() {
 
   // Once router is ready the transaction ID is attainable
   useEffect(() => {
-    // Must be logged in to see payment confirmation
-    if (!user.info && !user.loading) {
-      router.push("/login")
-    }
-
     // Router must be ready to access query parameters
     if (!router.isReady) {
       return
     }
 
     // Once the transaction ID is known, the associated data can be fetched
-    const { transaction_id } = router.query
-
-    // NOTE: Not sure when this will actually happen?
-    if (Array.isArray(transaction_id)) {
-      return
-    }
+    const transaction_id = router.query.transaction_id as string
 
     getTransaction(transaction_id).then(setTransaction).catch(setError)
   }, [router, user])
@@ -97,8 +88,10 @@ export default function TransactionPage() {
     <>
       <NextSeo title={t("payment-summary")} noindex={true}></NextSeo>
       <div className="max-w-11/12 my-0 mx-auto w-11/12 2xl:w-[1400px] 2xl:max-w-[1400px]">
-        <RelatedLink href="/wallet" pageTitle={t("user-wallet")} />
-        {content}
+        <LoginGuard>
+          <RelatedLink href="/wallet" pageTitle={t("user-wallet")} />
+          {content}
+        </LoginGuard>
       </div>
     </>
   )


### PR DESCRIPTION
The effect was running a second time when the stored value was
cleared, which results in default redirection to the user page.

I also updated the page to use the async hook and break the code up for
clarity.