### PR TITLE
Limit per-app download stats to the last 180 days

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -225,8 +225,15 @@ def get_stats(response: Response):
 
 
 @app.get("/stats/{appid}", status_code=200)
-def get_stats_for_app(appid: str, response: Response):
+def get_stats_for_app(appid: str, response: Response, all=False, days: int = 180):
     if value := stats.get_installs_by_ids([appid]).get(appid, None):
+        if all:
+            return value
+
+        per_day = value["installs_per_day"]
+        requested_dates = list(per_day.keys())[-days:]
+        requested_per_day = {date: per_day[date] for date in requested_dates}
+        value["installs_per_day"] = requested_per_day
         return value
 
     response.status_code = 404

--- a/backend/app/stats.py
+++ b/backend/app/stats.py
@@ -91,7 +91,7 @@ def _get_app_stats_per_day() -> Dict[str, Dict[str, int]]:
 
 
 def _get_stats(app_count: int) -> Dict[str, Dict[str, int]]:
-    edate = datetime.date.today()
+    edate = datetime.date.today() - datetime.timedelta(days=1)
     sdate = FIRST_STATS_DATE
 
     downloads_per_day: Dict[str, int] = {}

--- a/backend/tests/main.py
+++ b/backend/tests/main.py
@@ -308,22 +308,19 @@ def test_stats(client):
     yesterday = today - datetime.timedelta(days=1)
     day_before_yesterday = today - datetime.timedelta(days=2)
     expected = {
-        "countries": {"AD": 30, "BR": 60},
+        "countries": {"AD": 20, "BR": 40},
         "downloads_per_day": {},
         "delta_downloads_per_day": {},
         "updates_per_day": {},
-        "downloads": 3486,
+        "downloads": 2667,
         "number_of_apps": 3,
     }
     expected["delta_downloads_per_day"][day_before_yesterday.isoformat()] = 15
     expected["delta_downloads_per_day"][yesterday.isoformat()] = 15
-    expected["delta_downloads_per_day"][today.isoformat()] = 15
     expected["downloads_per_day"][day_before_yesterday.isoformat()] = 703
     expected["downloads_per_day"][yesterday.isoformat()] = 1964
-    expected["downloads_per_day"][today.isoformat()] = 819
     expected["updates_per_day"][day_before_yesterday.isoformat()] = 5
     expected["updates_per_day"][yesterday.isoformat()] = 5
-    expected["updates_per_day"][today.isoformat()] = 5
 
     assert response.status_code == 200
     assert response.json() == expected


### PR DESCRIPTION
The graph is not very useful for applications available on Flathub for
years, other than showing general trend of Flathub growing.