### PR TITLE
fix(wallet): deny transactions above Stripe max

### DIFF
--- a/backend/app/wallet/walletbase.py
+++ b/backend/app/wallet/walletbase.py
@@ -186,6 +186,8 @@ class WalletBase:
             raise WalletError(error="must be usd")
         if transaction.summary.value < 200:
             raise WalletError(error="transaction too small")
+        if transaction.summary.value > 99999999:
+            raise WalletError(error="transaction too large")
         if sum(row.amount for row in transaction.details) != transaction.summary.value:
             raise WalletError(error="detail sum does not match value")
         if not any(


### PR DESCRIPTION
This addresses part of #305 because transactions will be denied at the point of creation if they are larger than the maximum value Stripe can accept (8 digits). This is lower than the maximum value of a 4 byte integer which Postgres would otherwise limit us to.

The frontend should also apply some restriction in the transaction creation inputs, but that should wait until after #353 is merged because I'm introducing a currency input component there which will make that trivial.