### PR TITLE
feat(frontend): constrain currency inputs

### DIFF
--- a/frontend/src/components/application/AppVendingControls/PurchaseControls.tsx
+++ b/frontend/src/components/application/AppVendingControls/PurchaseControls.tsx
@@ -9,6 +9,7 @@ import {
 } from "react"
 import { toast } from "react-toastify"
 import { getAppVendingSetup, initiateAppPayment } from "../../../asyncs/vending"
+import { STRIPE_MAX_PAYMENT } from "../../../env"
 import { useAsync } from "../../../hooks/useAsync"
 import { getIntlLocale } from "../../../localize"
 import { Appstream } from "../../../types/Appstream"
@@ -140,6 +141,7 @@ const PurchaseControls: FunctionComponent<Props> = ({ app, vendingConfig }) => {
         value={amount}
         setValue={setAmount}
         minimum={vendingSetup.minimum_payment / 100}
+        maximum={STRIPE_MAX_PAYMENT}
       />
       <VendingSharesPreview
         price={amount.live * 100}

--- a/frontend/src/components/application/AppVendingControls/SetupControls.tsx
+++ b/frontend/src/components/application/AppVendingControls/SetupControls.tsx
@@ -9,6 +9,7 @@ import {
 } from "react"
 import { toast } from "react-toastify"
 import { getAppVendingSetup, setAppVendingSetup } from "../../../asyncs/vending"
+import { STRIPE_MAX_PAYMENT } from "../../../env"
 import { useAsync } from "../../../hooks/useAsync"
 import { Appstream } from "../../../types/Appstream"
 import { NumericInputValue } from "../../../types/Input"
@@ -128,6 +129,7 @@ const SetupControls: FunctionComponent<Props> = ({ app, vendingConfig }) => {
           <CurrencyInput
             value={recommendedDonation}
             setValue={setRecommendedDonation}
+            maximum={STRIPE_MAX_PAYMENT}
           />
           {minPayment.settled > recommendedDonation.live && (
             <p role="alert" className="my-2 text-colorDanger">
@@ -137,7 +139,11 @@ const SetupControls: FunctionComponent<Props> = ({ app, vendingConfig }) => {
         </div>
         <div>
           <label>{t("minimum-payment")}</label>
-          <CurrencyInput value={minPayment} setValue={setMinPayment} />
+          <CurrencyInput
+            value={minPayment}
+            setValue={setMinPayment}
+            maximum={STRIPE_MAX_PAYMENT}
+          />
         </div>
         <div>
           <label>{t("application-share")}</label>

--- a/frontend/src/components/payment/DonationInput.tsx
+++ b/frontend/src/components/payment/DonationInput.tsx
@@ -3,12 +3,11 @@ import Router from "next/router"
 import React, { FormEvent, FunctionComponent, useEffect, useState } from "react"
 import { toast } from "react-toastify"
 import { initiateDonation } from "../../asyncs/payment"
+import { FLATHUB_MIN_PAYMENT, STRIPE_MAX_PAYMENT } from "../../env"
 import { NumericInputValue } from "../../types/Input"
 import Button from "../Button"
 import CurrencyInput from "../CurrencyInput"
 import Spinner from "../Spinner"
-
-const minDonation = 5
 
 interface Props {
   org: string
@@ -18,8 +17,8 @@ const DonationInput: FunctionComponent<Props> = ({ org }) => {
   const { t } = useTranslation()
 
   const [amount, setAmount] = useState<NumericInputValue>({
-    live: minDonation,
-    settled: minDonation,
+    live: FLATHUB_MIN_PAYMENT,
+    settled: FLATHUB_MIN_PAYMENT,
   })
   const [submit, setSubmit] = useState(false)
   const [transaction, setTransaction] = useState("")
@@ -68,7 +67,12 @@ const DonationInput: FunctionComponent<Props> = ({ org }) => {
       <div className="flex flex-wrap items-center justify-center gap-5">
         {presets}
 
-        <CurrencyInput value={amount} setValue={setAmount} minimum={5} />
+        <CurrencyInput
+          value={amount}
+          setValue={setAmount}
+          minimum={FLATHUB_MIN_PAYMENT}
+          maximum={STRIPE_MAX_PAYMENT}
+        />
       </div>
       <Button>{t("make-donation")}</Button>
     </form>

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -90,3 +90,8 @@ export const VENDING_APP_SPLIT_URL = (
 
 export const IS_PRODUCTION: boolean =
   process.env.NEXT_PUBLIC_IS_PRODUCTION === "true"
+
+// Stripe can handle at most an 8 digit single transaction
+export const STRIPE_MAX_PAYMENT = 999999.99
+// Flathub enforces a minimum payment amount of $1 to cover fees
+export const FLATHUB_MIN_PAYMENT = 1


### PR DESCRIPTION
- Limit maximum input amount to respect the limit Stripe enforces on us.
  The backend will deny any forced requests send above this limit.
- Limit the minimum donation amount to $1

This may be considered to resolve #305 since transactions above the reported value cannot exist any more. Although we may want to only consider that fixed once the cancellation endpoint works regardless of payment intent errors.