### PR TITLE
Support GB in calculateHumanReadableSize()

### DIFF
--- a/frontend/src/size.ts
+++ b/frontend/src/size.ts
@@ -1,5 +1,7 @@
 export function calculateHumanReadableSize(size: number) {
-  if (size > 1_000_000) {
+  if (size > 1_000_000_000) {
+    return (size / 1_000_000_000).toFixed(2) + " GB"
+  } else if (size > 1_000_000) {
     return Math.round(size / 1_000_000) + " MB"
   } else {
     return Math.round(size / 1_000) + " KB"


### PR DESCRIPTION
With RetroDECK we now have a App that has multiple GB (2.5GB install size and 1.1GB download size), so it make sense to show the size in GB. The numbers are displayed with two decimal places: With so big sizes it makes sense to let the User know if the size is 1.01 or 1.99 GB.