### PR TITLE
Show users their owned applications

### DIFF
--- a/backend/app/logins.py
+++ b/backend/app/logins.py
@@ -746,6 +746,7 @@ def get_userinfo(login=Depends(login_state)):
     {
         "displayname": "Mx Human Person",
         "dev-flatpaks": [ "org.people.human.Appname" ],
+        "owned-flatpaks": [ "org.foo.bar.Appname" ],
     }
     ```
 
@@ -758,10 +759,17 @@ def get_userinfo(login=Depends(login_state)):
     if not login["state"].logged_in():
         return Response(status_code=204)
     user = login["user"]
-    ret = {"displayname": user.display_name, "dev-flatpaks": set()}
+    ret = {
+        "displayname": user.display_name,
+        "dev-flatpaks": set(),
+        "owned-flatpaks": set(),
+    }
     ret["auths"] = {}
 
     ret["dev-flatpaks"] = ret["dev-flatpaks"].union(user.dev_flatpaks(db))
+    ret["owned-flatpaks"] = {
+        app.app_id for app in models.UserOwnedApp.all_owned_by_user(db, user)
+    }
 
     gha = models.GithubAccount.by_user(db, user)
     if gha is not None:

--- a/frontend/pages/userpage.tsx
+++ b/frontend/pages/userpage.tsx
@@ -20,7 +20,8 @@ export default function Userpage({ providers }) {
       <div className="max-w-11/12 my-0 mx-auto flex w-11/12 flex-col gap-y-4 p-3 2xl:w-[1400px] 2xl:max-w-[1400px]">
         <LoginGuard>
           <UserDetails logins={providers} />
-          <UserApps />
+          <UserApps variant="owned" />
+          <UserApps variant="dev" />
           <div className="rounded-xl bg-bgColorSecondary p-4 shadow-md">
             <DeleteButton />
           </div>

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -55,7 +55,8 @@
   "error-already-logged-in": "The selected account is already logged in.",
   "failed-to-load-refresh": "The resource failed to load. Try refreshing.",
   "loading-user-apps": "Loading user apps…",
-  "your-apps": "Your Apps",
+  "your-apps": "Authored Apps",
+  "owned-apps": "Owned Apps",
   "app-logo": "{{app-name}} Logo",
   "user-page": "User Page",
   "user-wallet": "User Wallet",
@@ -227,5 +228,6 @@
   "value-at-least": "You must enter a value of at least {{value}}",
   "value-at-most": "You must enter a value of at most {{value}}",
   "unauthorized-to-view": "You are unauthorized to view this content.",
-  "payment-provider-error": "Our payment provider encountered an error. Try again later."
+  "payment-provider-error": "Our payment provider encountered an error. Try again later.",
+  "no-applications": "No applications to show."
 }

--- a/frontend/src/components/user/UserApps.tsx
+++ b/frontend/src/components/user/UserApps.tsx
@@ -6,13 +6,17 @@ import { useAsync } from "../../hooks/useAsync"
 import ApplicationCollection from "../application/Collection"
 import Spinner from "../Spinner"
 
-const UserApps: FunctionComponent = () => {
+interface Props {
+  variant: "dev" | "owned"
+}
+
+const UserApps: FunctionComponent<Props> = ({ variant }) => {
   const { t } = useTranslation()
   const user = useUserContext()
 
   const getApps = useCallback(
-    () => getAppsInfo(user.info["dev-flatpaks"]),
-    [user.info],
+    () => getAppsInfo(user.info[`${variant}-flatpaks`]),
+    [user.info, variant],
   )
   const { execute, status, value: apps } = useAsync(getApps, false)
 
@@ -25,7 +29,18 @@ const UserApps: FunctionComponent = () => {
     return <Spinner size="m" text={t("loading-user-apps")} />
   }
 
-  return <ApplicationCollection title={t("your-apps")} applications={apps} />
+  const title = t(variant === "dev" ? "your-apps" : "owned-apps")
+
+  if (apps.length === 0) {
+    return (
+      <>
+        <h2>{title}</h2>
+        <p>{t("no-applications")}</p>
+      </>
+    )
+  }
+
+  return <ApplicationCollection title={title} applications={apps} />
 }
 
 export default UserApps

--- a/frontend/src/types/Login.ts
+++ b/frontend/src/types/Login.ts
@@ -14,15 +14,11 @@ export interface AuthInfo {
   avatar?: string
   login?: string
 }
-export interface UserAuths {
-  github?: AuthInfo
-  gitlab?: AuthInfo
-  google?: AuthInfo
-}
 export interface UserInfo {
   displayname: string
   "dev-flatpaks": string[]
-  auths: UserAuths
+  "owned-flatpaks": string[]
+  auths: Record<string, AuthInfo>
 }
 
 // State houses user info, along with whether it's currently mid-request


### PR DESCRIPTION
- Included owned (purchased) applications in the userinfo endpoint
- Render owned applications on the user page

What I see having setup vending for and then purchased the test app:
![Screenshot from 2022-07-07 15-48-31](https://user-images.githubusercontent.com/5459452/177803291-d935327a-3401-4a37-8758-9b0612a398ad.png)

After deleting my account and recreating it (no longer own the app):
![Screenshot from 2022-07-07 15-48-54](https://user-images.githubusercontent.com/5459452/177803355-527c7f79-8de6-43eb-809a-c4af0891a084.png)

This is part of #256
