### PR TITLE
Disable invalid donation submission

### DIFF
--- a/frontend/src/components/payment/DonationInput.tsx
+++ b/frontend/src/components/payment/DonationInput.tsx
@@ -74,7 +74,13 @@ const DonationInput: FunctionComponent<Props> = ({ org }) => {
           maximum={STRIPE_MAX_PAYMENT}
         />
       </div>
-      <Button>{t("make-donation")}</Button>
+      <Button
+        disabled={
+          amount.live < FLATHUB_MIN_PAYMENT || amount.live > STRIPE_MAX_PAYMENT
+        }
+      >
+        {t("make-donation")}
+      </Button>
     </form>
   )
 }


### PR DESCRIPTION
Prevents the user from ignoring invalid donation amount feedback (unless they edit the page, which backend will deny anyway)