### PR TITLE
Rework how we display pagination

### DIFF
--- a/frontend/src/components/Pagination.stories.tsx
+++ b/frontend/src/components/Pagination.stories.tsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { ComponentMeta } from "@storybook/react"
+import Pagination from "./Pagination"
+
+export default {
+  title: "Components/Pagination",
+  component: Pagination,
+} as ComponentMeta<typeof Pagination>
+
+export const all = () => {
+  return (
+    <>
+      {/* this one should be hidden and not show up */}
+      <Pagination currentPage={1} pages={[1]} />
+      <Pagination currentPage={3} pages={[1, 2, 3, 4, 5]} />
+      <Pagination
+        currentPage={12}
+        pages={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}
+      />
+      <Pagination
+        currentPage={3}
+        pages={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -14,7 +14,7 @@ const Pagination: FunctionComponent<Props> = ({ currentPage, pages }) => {
   }
 
   return (
-    <div className="mx-auto mt-12 flex h-12 w-min items-center rounded-xl bg-bgColorSecondary text-xl text-colorSecondary shadow-md">
+    <nav className="mx-auto mt-12 flex h-12 w-min items-center space-x-2 text-xl text-gray-900 dark:text-gray-50">
       {pages
         .filter(
           (page) =>
@@ -41,16 +41,17 @@ const Pagination: FunctionComponent<Props> = ({ currentPage, pages }) => {
                     },
                   })
                 }}
+                aria-current={isActive ? "page" : null}
                 className={`${
-                  isActive ? `font-bold` : ""
-                } h-12 w-12 py-2 text-center no-underline duration-500 first:rounded-tl-xl first:rounded-bl-xl last:rounded-tr-xl last:rounded-br-xl hover:cursor-pointer hover:bg-colorPrimary hover:text-gray-100`}
+                  isActive ? `bg-colorPrimary text-gray-50` : ""
+                }  h-12 w-12 rounded-full py-2 text-center no-underline duration-500 hover:cursor-pointer hover:opacity-50`}
               >
                 {curr}
               </a>
             </React.Fragment>
           )
         })}
-    </div>
+    </nav>
   )
 }
 export default Pagination


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5943908/180953359-312dec4c-1e29-4de8-b2ff-284075782cc6.png)


![image](https://user-images.githubusercontent.com/5943908/180953491-b9e8ae37-d181-4d0b-ac4b-572881b52120.png)

@bertob This is a quick iteration on your design. It's much bigger for now, otherwise we would have to do a different version for mobile form factors.

I'm also not sure about the hover being the same effect as the current page.


Closes https://github.com/flathub/website/issues/500