### PR TITLE
Use last 30 days for Popular Apps collection

### DIFF
--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -10,7 +10,7 @@ export const STATS_DETAILS = (id: string): string => `${BASE_URI}/stats/${id}`
 export const STATS = `${BASE_URI}/stats`
 export const SEARCH_APP = (query: string): string =>
   `${BASE_URI}/search/${encodeURIComponent(query)}`
-export const POPULAR_URL: string = `${BASE_URI}/popular`
+export const POPULAR_URL: string = `${BASE_URI}/popular/30`
 export const EDITORS_PICKS_APPS_URL: string = `${BASE_URI}/picks/apps`
 export const RECENTLY_UPDATED_URL: string = `${BASE_URI}/collection/recently-updated`
 export const RECENTLY_ADDED_URL: string = `${BASE_URI}/collection/recently-added`


### PR DESCRIPTION
The Popular Apps collection has currently a problem: It displays a list of Apps with the most downloads of all time. This list if of course full of Apps that are on Flathub for some time. It would be better to show the Apps with the most downloads in the last 30 Days (one month). This would also include never Apps.