### PR TITLE
Add ownership tokens UI to frontend

### DIFF
--- a/frontend/pages/apps/manage/[appId].tsx
+++ b/frontend/pages/apps/manage/[appId].tsx
@@ -30,6 +30,7 @@ export default function AppManagementPage({
           app={app}
           vendingConfig={vendingConfig}
         />
+        <AppVendingControls.OwnershipTokens app={app} />
       </>
     )
   } else {

--- a/frontend/pages/apps/purchase/[appId].tsx
+++ b/frontend/pages/apps/purchase/[appId].tsx
@@ -22,6 +22,7 @@ export default function AppPurchasePage({
           app={app}
           vendingConfig={vendingConfig}
         />
+        <AppVendingControls.OwnershipTokenRedeemDialog app={app} />
       </LoginGuard>
     </div>
   )

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -236,5 +236,6 @@
   "enable-app-vending": "Enable Application Vending",
   "require-payment": "Require Payment",
   "permission-denied": "You don't have permission to do that.",
-  "ownership-tokens": "Ownership Tokens"
+  "ownership-tokens": "Ownership Tokens",
+  "redeem-token": "Redeem Token"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -240,5 +240,8 @@
   "redeem-token": "Redeem Token",
   "status-redeemed": "Redeemed",
   "status-unredeemed": "Unredeemed",
-  "token-cancelled": "Token successfully cancelled"
+  "token-cancelled": "Token successfully cancelled",
+  "create-tokens": "Create Tokens",
+  "submit": "Submit",
+  "token-creation-placeholder": "Enter a list of names on separate lines, each will identify a new ownership token."
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -237,5 +237,7 @@
   "require-payment": "Require Payment",
   "permission-denied": "You don't have permission to do that.",
   "ownership-tokens": "Ownership Tokens",
-  "redeem-token": "Redeem Token"
+  "redeem-token": "Redeem Token",
+  "status-redeemed": "Redeemed",
+  "status-unredeemed": "Unredeemed"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -235,5 +235,6 @@
   "system": "System",
   "enable-app-vending": "Enable Application Vending",
   "require-payment": "Require Payment",
-  "permission-denied": "You don't have permission to do that."
+  "permission-denied": "You don't have permission to do that.",
+  "ownership-tokens": "Ownership Tokens"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -234,5 +234,6 @@
   "education": "Education",
   "system": "System",
   "enable-app-vending": "Enable Application Vending",
-  "require-payment": "Require Payment"
+  "require-payment": "Require Payment",
+  "permission-denied": "You don't have permission to do that."
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -243,5 +243,8 @@
   "token-cancelled": "Token successfully cancelled",
   "create-tokens": "Create Tokens",
   "submit": "Submit",
-  "token-creation-placeholder": "Enter a list of names on separate lines, each will identify a new ownership token."
+  "token-creation-placeholder": "Enter a list of names on separate lines, each will identify a new ownership token.",
+  "token-redeemed": "Token successfully redeemed",
+  "token-failed": "Failed to redeem token",
+  "token-redeem-placeholder": "Enter an ownership token"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -239,5 +239,6 @@
   "ownership-tokens": "Ownership Tokens",
   "redeem-token": "Redeem Token",
   "status-redeemed": "Redeemed",
-  "status-unredeemed": "Unredeemed"
+  "status-unredeemed": "Unredeemed",
+  "token-cancelled": "Token successfully cancelled"
 }

--- a/frontend/src/asyncs/vending.ts
+++ b/frontend/src/asyncs/vending.ts
@@ -5,6 +5,9 @@ import {
   VENDING_DASHBOARD_URL,
   VENDING_ONBOARDING_URL,
   VENDING_STATUS_URL,
+  VENDING_TOKENS_CANCEL_URL,
+  VENDING_TOKENS_REDEEM_URL,
+  VENDING_TOKENS_URL,
 } from "../env"
 import { APIResponseError } from "../types/API"
 import {
@@ -15,6 +18,9 @@ import {
   VendingSetup,
   VendingSplit,
   VendingStatus,
+  VendingTokenCancellation,
+  VendingTokenList,
+  VendingTokenRedemption,
 } from "../types/Vending"
 
 // API responds with this status code if onboarding has not begun
@@ -246,6 +252,119 @@ export async function initiateAppPayment(
 
     const msg = {
       "stripe-payment-intent-build-failed": "payment-provider-error",
+    }[data.error]
+
+    throw msg ?? "network-error-try-again"
+  }
+}
+
+export async function getVendingTokens(
+  appId: string,
+): Promise<VendingTokenList> {
+  let res: Response
+  try {
+    res = await fetch(VENDING_TOKENS_URL(appId), {
+      method: "GET",
+      credentials: "include",
+    })
+  } catch {
+    throw "network-error-try-again"
+  }
+
+  if (res.ok) {
+    const data: VendingTokenList = await res.json()
+    return data
+  } else {
+    throw "network-error-try-again"
+  }
+}
+
+export async function createVendingTokens(
+  appId: string,
+  names: string[],
+): Promise<VendingTokenList> {
+  let res: Response
+  try {
+    res = await fetch(VENDING_TOKENS_URL(appId), {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(names),
+    })
+  } catch {
+    throw "network-error-try-again"
+  }
+
+  if (res.ok) {
+    const data: VendingTokenList = await res.json()
+    return data
+  } else {
+    const data: APIResponseError = await res.json()
+
+    const msg = {
+      "permission-denied": "permission-denied",
+    }[data.error]
+
+    throw msg ?? "network-error-try-again"
+  }
+}
+
+export async function cancelVendingTokens(
+  appId: string,
+  tokens: string[],
+): Promise<VendingTokenCancellation[]> {
+  let res: Response
+  try {
+    res = await fetch(VENDING_TOKENS_CANCEL_URL(appId), {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(tokens),
+    })
+  } catch {
+    throw "network-error-try-again"
+  }
+
+  if (res.ok) {
+    const data: VendingTokenCancellation[] = await res.json()
+    return data
+  } else {
+    const data: APIResponseError = await res.json()
+
+    const msg = {
+      "permission-denied": "permission-denied",
+    }[data.error]
+
+    throw msg ?? "network-error-try-again"
+  }
+}
+
+export async function redeemVendingToken(
+  appId: string,
+  token: string,
+): Promise<VendingTokenRedemption> {
+  let res: Response
+  try {
+    res = await fetch(VENDING_TOKENS_REDEEM_URL(appId, token), {
+      method: "POST",
+      credentials: "include",
+    })
+  } catch {
+    throw "network-error-try-again"
+  }
+
+  if (res.ok) {
+    const data: VendingTokenRedemption = await res.json()
+    return data
+  } else {
+    const data: APIResponseError = await res.json()
+
+    const msg = {
+      "already-owned": "network-error-try-again",
     }[data.error]
 
     throw msg ?? "network-error-try-again"

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCancelButton.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCancelButton.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from "next-i18next"
+import { FunctionComponent, useCallback, useEffect } from "react"
+import { toast } from "react-toastify"
+import { cancelVendingTokens } from "../../../../asyncs/vending"
+import { useAsync } from "../../../../hooks/useAsync"
+import { VendingToken } from "../../../../types/Vending"
+import Button from "../../../Button"
+import Spinner from "../../../Spinner"
+
+interface Props {
+  token: VendingToken
+  appId: string
+}
+
+const TokenCancelButton: FunctionComponent<Props> = ({ token, appId }) => {
+  const { t } = useTranslation()
+
+  const {
+    execute: onClick,
+    value,
+    status,
+    error,
+  } = useAsync(
+    useCallback(
+      () => cancelVendingTokens(appId, [token.token]),
+      [appId, token.token],
+    ),
+    false,
+  )
+
+  useEffect(() => {
+    if (error) {
+      toast.error(t(error))
+    }
+  }, [t, error])
+
+  if (status === "pending") {
+    return <Spinner size="s" />
+  }
+
+  // Button is spent after successful use
+  if (status === "success" && value?.[0].status === "cancelled") {
+    return <></>
+  }
+
+  return (
+    <Button variant="destructive" onClick={onClick}>
+      {t("cancel")}
+    </Button>
+  )
+}
+
+export default TokenCancelButton

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCancelButton.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCancelButton.tsx
@@ -10,9 +10,14 @@ import Spinner from "../../../Spinner"
 interface Props {
   token: VendingToken
   appId: string
+  setState: React.Dispatch<React.SetStateAction<string>>
 }
 
-const TokenCancelButton: FunctionComponent<Props> = ({ token, appId }) => {
+const TokenCancelButton: FunctionComponent<Props> = ({
+  token,
+  appId,
+  setState,
+}) => {
   const { t } = useTranslation()
 
   const {
@@ -33,6 +38,13 @@ const TokenCancelButton: FunctionComponent<Props> = ({ token, appId }) => {
       toast.error(t(error))
     }
   }, [t, error])
+
+  useEffect(() => {
+    if (value?.[0].status === "cancelled") {
+      setState("cancelled")
+      toast.success(t("token-cancelled"))
+    }
+  }, [value, setState, t])
 
   if (status === "pending") {
     return <Spinner size="s" />

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
@@ -1,0 +1,58 @@
+import { Dialog, Transition } from "@headlessui/react"
+import { useTranslation } from "next-i18next"
+import { Fragment, FunctionComponent, useCallback, useState } from "react"
+import { createVendingTokens } from "../../../../asyncs/vending"
+import { Appstream } from "../../../../types/Appstream"
+import Button from "../../../Button"
+
+interface Props {
+  app: Appstream
+}
+
+/**
+ * The control elements to view and add/cancel ownership tokens for an app.
+ */
+const TokenCreateDialog: FunctionComponent<Props> = ({ app }) => {
+  const { t } = useTranslation()
+
+  const [shown, setShown] = useState(false)
+  const [text, setText] = useState("")
+
+  const textUpdate = useCallback((event) => setText(event.target.value), [])
+  const onSubmit = useCallback(() => {
+    setShown(false)
+
+    // Strip leading and trailing whitespace characters
+    const names = text.split(/\s*\n\s*/).filter((name) => name !== "")
+
+    if (names.length > 0) {
+      createVendingTokens(app.id, names)
+    }
+  }, [app.id, text])
+
+  return (
+    <>
+      <Button onClick={() => setShown(true)}>Create tokens</Button>
+      <Transition appear show={shown} as={Fragment}>
+        <Dialog as="div" onClose={() => setShown(false)}>
+          <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
+
+          <div className="fixed inset-0 flex items-center justify-center p-4">
+            <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-bgColorPrimary p-14 shadow-md">
+              <Dialog.Title className="m-0">Create tokens</Dialog.Title>
+              <label>Token names</label>
+              <textarea
+                placeholder="Enter a list of names on separate lines, each will identify a new ownership token."
+                value={text}
+                onChange={textUpdate}
+              />
+              <Button onClick={onSubmit}>Submit</Button>
+            </Dialog.Panel>
+          </div>
+        </Dialog>
+      </Transition>
+    </>
+  )
+}
+
+export default TokenCreateDialog

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
@@ -32,21 +32,21 @@ const TokenCreateDialog: FunctionComponent<Props> = ({ app }) => {
 
   return (
     <>
-      <Button onClick={() => setShown(true)}>Create tokens</Button>
+      <Button onClick={() => setShown(true)}>{t("create-tokens")}</Button>
       <Transition appear show={shown} as={Fragment}>
         <Dialog as="div" onClose={() => setShown(false)}>
           <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
           <div className="fixed inset-0 flex items-center justify-center p-4">
             <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-bgColorPrimary p-14 shadow-md">
-              <Dialog.Title className="m-0">Create tokens</Dialog.Title>
-              <label>Token names</label>
+              <Dialog.Title className="m-0">{t("create-tokens")}</Dialog.Title>
               <textarea
-                placeholder="Enter a list of names on separate lines, each will identify a new ownership token."
+                placeholder={t("token-creation-placeholder")}
                 value={text}
                 onChange={textUpdate}
+                className="h-40 rounded-xl p-3"
               />
-              <Button onClick={onSubmit}>Submit</Button>
+              <Button onClick={onSubmit}>{t("submit")}</Button>
             </Dialog.Panel>
           </div>
         </Dialog>

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 /**
- * The control elements to view and add/cancel ownership tokens for an app.
+ * The button to open a model dialog where application ownership tokens can be generated.
  */
 const TokenCreateDialog: FunctionComponent<Props> = ({ app }) => {
   const { t } = useTranslation()

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
@@ -36,7 +36,9 @@ const TokenList: FunctionComponent<Props> = ({ app }) => {
       <div className="flex flex-col gap-2 rounded-2xl bg-bgColorSecondary p-2">
         {tokens.tokens.map((token) => (
           <Disclosure key={token.id}>
-            {({ open }) => <TokenListItem open={open} token={token} />}
+            {({ open }) => (
+              <TokenListItem open={open} token={token} appId={app.id} />
+            )}
           </Disclosure>
         ))}
         <TokenCreateDialog app={app} />

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
@@ -1,0 +1,53 @@
+import { Disclosure } from "@headlessui/react"
+import { useTranslation } from "next-i18next"
+import { FunctionComponent, ReactElement, useCallback } from "react"
+import { getVendingTokens } from "../../../../asyncs/vending"
+import { useAsync } from "../../../../hooks/useAsync"
+import { Appstream } from "../../../../types/Appstream"
+import Spinner from "../../../Spinner"
+import TokenListItem from "./TokenListItem"
+
+interface Props {
+  app: Appstream
+}
+
+/**
+ * The control elements to view and add/cancel ownership tokens for an app.
+ */
+const TokenList: FunctionComponent<Props> = ({ app }) => {
+  const { t } = useTranslation()
+
+  const {
+    value: tokens,
+    status,
+    error,
+  } = useAsync(useCallback(() => getVendingTokens(app.id), [app.id]))
+
+  if (["pending", "idle"].includes(status)) {
+    return <Spinner size="m" />
+  }
+
+  let content: ReactElement
+  if (error) {
+    content = <p>{t(error)}</p>
+  } else {
+    content = (
+      <div className="flex flex-col gap-2 rounded-2xl bg-bgColorSecondary p-2">
+        {tokens.tokens.map((token) => (
+          <Disclosure key={token.id}>
+            {({ open }) => <TokenListItem open={open} token={token} />}
+          </Disclosure>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <h3>{t("ownership-tokens")}</h3>
+      {content}
+    </>
+  )
+}
+
+export default TokenList

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
@@ -5,6 +5,7 @@ import { getVendingTokens } from "../../../../asyncs/vending"
 import { useAsync } from "../../../../hooks/useAsync"
 import { Appstream } from "../../../../types/Appstream"
 import Spinner from "../../../Spinner"
+import TokenCreateDialog from "./TokenCreateDialog"
 import TokenListItem from "./TokenListItem"
 
 interface Props {
@@ -38,6 +39,7 @@ const TokenList: FunctionComponent<Props> = ({ app }) => {
             {({ open }) => <TokenListItem open={open} token={token} />}
           </Disclosure>
         ))}
+        <TokenCreateDialog app={app} />
       </div>
     )
   }

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
@@ -3,13 +3,15 @@ import { useTranslation } from "next-i18next"
 import { FunctionComponent } from "react"
 import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md"
 import { VendingToken } from "../../../../types/Vending"
+import TokenCancelButton from "./TokenCancelButton"
 
 interface Props {
   open: boolean
   token: VendingToken
+  appId: string
 }
 
-const TokenListItem: FunctionComponent<Props> = ({ open, token }) => {
+const TokenListItem: FunctionComponent<Props> = ({ open, token, appId }) => {
   const { t } = useTranslation()
 
   return (
@@ -24,12 +26,19 @@ const TokenListItem: FunctionComponent<Props> = ({ open, token }) => {
           <MdArrowDropDown className="text-2xl" />
         )}
       </Disclosure.Button>
-      <Disclosure.Panel>
-        <span>{t("transaction-summary-created", { date: token.created })}</span>
-        <br />
-        <span>{t("transaction-summary-status", { status: token.state })}</span>
-        <br />
-        <span>{token.token}</span>
+      <Disclosure.Panel className="flex justify-between pl-4 pr-4">
+        <div>
+          <span>
+            {t("transaction-summary-created", { date: token.created })}
+          </span>
+          <br />
+          <span>
+            {t("transaction-summary-status", { status: token.state })}
+          </span>
+          <br />
+          <span>{token.token}</span>
+        </div>
+        <TokenCancelButton token={token} appId={appId} />
       </Disclosure.Panel>
     </>
   )

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
@@ -1,0 +1,38 @@
+import { Disclosure } from "@headlessui/react"
+import { useTranslation } from "next-i18next"
+import { FunctionComponent } from "react"
+import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md"
+import { VendingToken } from "../../../../types/Vending"
+
+interface Props {
+  open: boolean
+  token: VendingToken
+}
+
+const TokenListItem: FunctionComponent<Props> = ({ open, token }) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <Disclosure.Button className="flex justify-between rounded-lg border p-2 hover:bg-colorHighlight focus:outline-none focus-visible:ring focus-visible:ring-opacity-75">
+        <span>
+          {token.id} - {token.name}
+        </span>
+        {!open ? (
+          <MdArrowDropUp className="text-2xl" />
+        ) : (
+          <MdArrowDropDown className="text-2xl" />
+        )}
+      </Disclosure.Button>
+      <Disclosure.Panel>
+        <span>{t("transaction-summary-created", { date: token.created })}</span>
+        <br />
+        <span>{t("transaction-summary-status", { status: token.state })}</span>
+        <br />
+        <span>{token.token}</span>
+      </Disclosure.Panel>
+    </>
+  )
+}
+
+export default TokenListItem

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
@@ -1,5 +1,6 @@
 import { Disclosure } from "@headlessui/react"
 import { useTranslation } from "next-i18next"
+import { useState } from "react"
 import { FunctionComponent } from "react"
 import { MdArrowDropDown, MdArrowDropUp } from "react-icons/md"
 import { VendingToken } from "../../../../types/Vending"
@@ -14,13 +15,15 @@ interface Props {
 const TokenListItem: FunctionComponent<Props> = ({ open, token, appId }) => {
   const { t } = useTranslation()
 
+  const [state, setState] = useState(token.state)
+
   return (
     <>
       <Disclosure.Button className="flex justify-between rounded-lg border p-2 hover:bg-colorHighlight focus:outline-none focus-visible:ring focus-visible:ring-opacity-75">
         <div className="grid w-full grid-cols-3 justify-items-start">
           <span>{token.id}</span>
           <span>{token.name}</span>
-          <span>{t(`status-${token.state}`)}</span>
+          <span>{t(`status-${state}`)}</span>
         </div>
         {!open ? (
           <MdArrowDropUp className="text-2xl" />
@@ -35,8 +38,8 @@ const TokenListItem: FunctionComponent<Props> = ({ open, token, appId }) => {
             {t("transaction-summary-created", { date: token.created })}
           </span>
         </div>
-        {token.state === "unredeemed" && (
-          <TokenCancelButton token={token} appId={appId} />
+        {state === "unredeemed" && (
+          <TokenCancelButton token={token} appId={appId} setState={setState} />
         )}
       </Disclosure.Panel>
     </>

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
@@ -17,28 +17,27 @@ const TokenListItem: FunctionComponent<Props> = ({ open, token, appId }) => {
   return (
     <>
       <Disclosure.Button className="flex justify-between rounded-lg border p-2 hover:bg-colorHighlight focus:outline-none focus-visible:ring focus-visible:ring-opacity-75">
-        <span>
-          {token.id} - {token.name}
-        </span>
+        <div className="grid w-full grid-cols-3 justify-items-start">
+          <span>{token.id}</span>
+          <span>{token.name}</span>
+          <span>{t(`status-${token.state}`)}</span>
+        </div>
         {!open ? (
           <MdArrowDropUp className="text-2xl" />
         ) : (
           <MdArrowDropDown className="text-2xl" />
         )}
       </Disclosure.Button>
-      <Disclosure.Panel className="flex justify-between pl-4 pr-4">
-        <div>
+      <Disclosure.Panel className="flex flex-wrap justify-between gap-y-4 pl-4 pr-4">
+        <div className="flex flex-col gap-4">
+          <span>{token.token}</span>
           <span>
             {t("transaction-summary-created", { date: token.created })}
           </span>
-          <br />
-          <span>
-            {t("transaction-summary-status", { status: token.state })}
-          </span>
-          <br />
-          <span>{token.token}</span>
         </div>
-        <TokenCancelButton token={token} appId={appId} />
+        {token.state === "unredeemed" && (
+          <TokenCancelButton token={token} appId={appId} />
+        )}
       </Disclosure.Panel>
     </>
   )

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from "next-i18next"
+import { FunctionComponent, useCallback, useEffect, useState } from "react"
+import { toast } from "react-toastify"
+import { redeemVendingToken } from "../../../../asyncs/vending"
+import { useAsync } from "../../../../hooks/useAsync"
+import { Appstream } from "../../../../types/Appstream"
+import Button from "../../../Button"
+
+interface Props {
+  app: Appstream
+}
+
+/**
+ * A set of controls for redemption of application ownership tokens.
+ */
+const TokenRedeemDialog: FunctionComponent<Props> = ({ app }) => {
+  const { t } = useTranslation()
+
+  const [text, setText] = useState("")
+
+  const textUpdate = useCallback((event) => setText(event.target.value), [])
+  const {
+    execute: onSubmit,
+    value,
+    status,
+    error,
+  } = useAsync(
+    useCallback(() => {
+      // Strip leading and trailing whitespace characters
+      const token = text.trim()
+
+      setText("")
+
+      if (token.length > 0) {
+        return redeemVendingToken(app.id, token)
+      }
+    }, [app.id, text]),
+    false,
+  )
+
+  useEffect(() => {
+    if (value?.status === "failure") {
+      toast.error("Failed to redeem token")
+    }
+    if (value?.status === "success") {
+      toast.success("Ownership token redeemed")
+    }
+  }, [value])
+
+  return (
+    <div className="inline-flex gap-2 rounded-xl bg-bgColorSecondary p-4">
+      <input
+        type="text"
+        placeholder="Enter an ownership token"
+        value={text}
+        onChange={textUpdate}
+        className="w-80 rounded-xl bg-bgColorPrimary p-2"
+      />
+      <Button onClick={onSubmit}>{t("redeem-token")}</Button>
+    </div>
+  )
+}
+
+export default TokenRedeemDialog

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
@@ -5,6 +5,7 @@ import { redeemVendingToken } from "../../../../asyncs/vending"
 import { useAsync } from "../../../../hooks/useAsync"
 import { Appstream } from "../../../../types/Appstream"
 import Button from "../../../Button"
+import Spinner from "../../../Spinner"
 
 interface Props {
   app: Appstream
@@ -39,19 +40,29 @@ const TokenRedeemDialog: FunctionComponent<Props> = ({ app }) => {
   )
 
   useEffect(() => {
+    if (error) {
+      toast.error(t(error))
+    }
+  }, [t, error])
+
+  useEffect(() => {
     if (value?.status === "failure") {
-      toast.error("Failed to redeem token")
+      toast.error(t("token-failed"))
     }
     if (value?.status === "success") {
-      toast.success("Ownership token redeemed")
+      toast.success(t("token-redeemed"))
     }
-  }, [value])
+  }, [value, t])
+
+  if (status === "pending") {
+    return <Spinner size={"s"} />
+  }
 
   return (
     <div className="inline-flex gap-2 rounded-xl bg-bgColorSecondary p-4">
       <input
         type="text"
-        placeholder="Enter an ownership token"
+        placeholder={t("token-redeem-placeholder")}
         value={text}
         onChange={textUpdate}
         className="w-80 rounded-xl bg-bgColorPrimary p-2"

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "next-i18next"
 import { FunctionComponent, useCallback, useEffect, useState } from "react"
 import { toast } from "react-toastify"
+import { VendingTokenRedemption } from "src/types/Vending"
 import { redeemVendingToken } from "../../../../asyncs/vending"
 import { useAsync } from "../../../../hooks/useAsync"
 import { Appstream } from "../../../../types/Appstream"
@@ -25,16 +26,16 @@ const TokenRedeemDialog: FunctionComponent<Props> = ({ app }) => {
     value,
     status,
     error,
-  } = useAsync(
+  } = useAsync<VendingTokenRedemption>(
     useCallback(() => {
       // Strip leading and trailing whitespace characters
       const token = text.trim()
 
       setText("")
 
-      if (token.length > 0) {
-        return redeemVendingToken(app.id, token)
-      }
+      return token !== ""
+        ? redeemVendingToken(app.id, token)
+        : Promise.resolve(null)
     }, [app.id, text]),
     false,
   )

--- a/frontend/src/components/application/AppVendingControls/index.tsx
+++ b/frontend/src/components/application/AppVendingControls/index.tsx
@@ -1,3 +1,4 @@
 export { default as SetupControls } from "./SetupControls"
 export { default as PurchaseControls } from "./PurchaseControls"
 export { default as OwnershipTokens } from "./OwnershipTokens/TokenList"
+export { default as OwnershipTokenRedeemDialog } from "./OwnershipTokens/TokenRedeemDialog"

--- a/frontend/src/components/application/AppVendingControls/index.tsx
+++ b/frontend/src/components/application/AppVendingControls/index.tsx
@@ -1,2 +1,3 @@
 export { default as SetupControls } from "./SetupControls"
 export { default as PurchaseControls } from "./PurchaseControls"
+export { default as OwnershipTokens } from "./OwnershipTokens/TokenList"

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -87,6 +87,15 @@ export const VENDING_APP_SPLIT_URL = (
 ) => {
   return `${APP_VENDING_BASE_URL}/${appId}/${currency}/${value}`
 }
+export const VENDING_TOKENS_URL = (appId: string) => {
+  return `${APP_VENDING_BASE_URL}/${appId}/tokens`
+}
+export const VENDING_TOKENS_CANCEL_URL = (appId: string) => {
+  return `${VENDING_TOKENS_URL(appId)}/cancel`
+}
+export const VENDING_TOKENS_REDEEM_URL = (appId: string, token: string) => {
+  return `${VENDING_TOKENS_URL(appId)}/redeem/${token}`
+}
 
 export const IS_PRODUCTION: boolean =
   process.env.NEXT_PUBLIC_IS_PRODUCTION === "true"

--- a/frontend/src/types/Vending.ts
+++ b/frontend/src/types/Vending.ts
@@ -58,3 +58,27 @@ export interface ProposedPayment {
   currency: string
   amount: number
 }
+
+export interface VendingToken {
+  id: string
+  state: "unredeemed" | "redeemed" | "cancelled"
+  name: string
+  token?: string
+  created: string
+  changed: string
+}
+
+export interface VendingTokenList extends APIResponseOk {
+  total: number
+  tokens: VendingToken[]
+}
+
+export interface VendingTokenCancellation {
+  token: string
+  status: "invalid" | "cancelled" | "error"
+}
+
+export interface VendingTokenRedemption {
+  status: "success" | "failure"
+  reason: string
+}


### PR DESCRIPTION
- Adds a list of existing "ownership tokens" (as I'm referring to them in rendering), with controls to create more (through a modal).
- Adds a simple token redemption form to the purchase page for an application.

![image](https://user-images.githubusercontent.com/5459452/181264464-c2d7c94b-ff31-44d1-b403-87c33136df99.png)
(Note that the empty name strings are prevented from occurring by latest code)
![image](https://user-images.githubusercontent.com/5459452/181266399-0cf58518-c82c-4736-8667-56cd8266c106.png)
![image](https://user-images.githubusercontent.com/5459452/181263892-916e58d4-66fb-4372-98ee-0c4974518422.png)


This is a pretty basic implementation of the rendering and key functions, some follow up tasks (which I'll open issues for on merge):

- Update the token list immediately on creation of new tokens
- Add pagination to the tokens list

Closes #481