### PR TITLE
fix(frontend): unblock history back navigation

### DIFF
--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -16,7 +16,7 @@ export default function DeveloperLoginPortal({ providers }) {
   useEffect(() => {
     // Already logged in, just redirect to userpage
     if (user.info && !user.loading) {
-      Router.push("/userpage")
+      Router.replace("/userpage")
     }
   }, [user])
 

--- a/frontend/src/components/login/LoginGuard.tsx
+++ b/frontend/src/components/login/LoginGuard.tsx
@@ -17,7 +17,8 @@ const LoginGuard: FunctionComponent = ({ children }) => {
   // Content unsuitable if not logged in, send user to login page
   useEffect(() => {
     if (!user.info && !user.loading) {
-      router.push(`/login?returnTo=${encodeURIComponent(router.asPath)}`)
+      // Avoid new entry in history stack to allow backward navigation
+      router.replace(`/login?returnTo=${encodeURIComponent(router.asPath)}`)
     }
   }, [user, router])
 


### PR DESCRIPTION
Use of router.replace prevents new entry on the stack, so back goes to
page before the one redirected away from

fixes #513