### PR TITLE
Revert "Use new FastApi integration"

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,10 +5,9 @@ import sentry_sdk
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse, PlainTextResponse
-from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
-from sentry_sdk.integrations.starlette import StarletteIntegration
 
 from . import (
     apps,
@@ -40,10 +39,9 @@ if config.settings.sentry_dsn:
         integrations=[
             SqlalchemyIntegration(),
             RedisIntegration(),
-            StarletteIntegration(),
-            FastApiIntegration(),
         ],
     )
+    app.add_middleware(SentryAsgiMiddleware)
 
 origins = config.settings.cors_origins.split(" ")
 


### PR DESCRIPTION
This reverts commit 1bbb6dac2ea9283540de2f645e7f401dd5cc1734.


This seems to be in the right timeframe for when most issues started. I thought it might have been better reporting, but we'll see.

I also discovered, that they say in the issue tracker, that it's an alpha feature, which wasn't clear from the release https://github.com/getsentry/sentry-python/releases/tag/1.8.0

For e.g. https://github.com/getsentry/sentry-python/pull/1532