### PR TITLE
Collapsed the long app descriptions

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -249,5 +249,7 @@
   "token-redeem-placeholder": "Enter an ownership token",
   "open-menu": "Open Menu",
   "open-user-menu": "Open User Menu",
-  "your-profile": "Your Profile"
+  "your-profile": "Your Profile",
+  "show-more":"Show More",
+  "show-less":"Show Less"
 }


### PR DESCRIPTION
Implemented a method to collapse by default all descriptions that are longer
than a specified value. Created a button for extending the description and
one for collapsing it.
Addressed issue #537 

Signed-off-by: Mihai State <mihai.state@codethink.co.uk>