### PR TITLE
Use new poetry installer

### DIFF
--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: main
     paths:
-      - 'backend/**'
-      - '.github/workflows/backend_ci.yml'
+      - "backend/**"
+      - ".github/workflows/backend_ci.yml"
   pull_request:
     branches: main
     paths:
-      - 'backend/**'
-      - '.github/workflows/backend_ci.yml'
+      - "backend/**"
+      - ".github/workflows/backend_ci.yml"
   workflow_dispatch:
 
 jobs:
@@ -29,7 +29,7 @@ jobs:
 
       - name: Setup Poetry
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          curl -sSL https://install.python-poetry.org | python -
           echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
       - uses: actions/cache@v3

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,13 +5,13 @@ RUN apt-get update && \
         build-essential libcairo2-dev libgirepository1.0-dev \
         gir1.2-ostree-1.0 flatpak
 
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | /usr/local/bin/python - && \
+RUN curl -sSL https://install.python-poetry.org | /usr/local/bin/python - && \
     python -m venv /venv && \
     /venv/bin/python -m pip install -U pip
 
 COPY pyproject.toml poetry.lock /
 
-RUN $HOME/.poetry/bin/poetry export -o requirements.txt && \
+RUN $HOME/.local/bin/poetry export -o requirements.txt && \
     /venv/bin/pip install -r requirements.txt
 
 FROM python:3.10-slim


### PR DESCRIPTION
The old installer has been deprecated, so we're using the new recommended way now.
This should hopefully help fixing the issues with newer python dep MRs not building okay.