### PR TITLE
Add API for EOL rebase

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -157,11 +157,8 @@ def get_eol_rebase():
 def get_eol_rebase_appid(
     appid: str,
 ):
-    for new_id, old_id_list in db.get_json_key("eol_rebase").items():
-        if appid in old_id_list:
-            return new_id
-
-    return None
+    if value := db.get_json_key(f"eol_rebase:{appid}"):
+        return value
 
 
 @app.get("/projectgroup")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -149,15 +149,15 @@ def get_developer(
 
 
 @app.get("/eol/rebase")
-def get_eol_rebase_appid():
-    return db.get_json_key(f"eol_rebase")
+def get_eol_rebase():
+    return db.get_json_key("eol_rebase")
 
 
 @app.get("/eol/rebase/{appid}")
 def get_eol_rebase_appid(
     appid: str,
 ):
-    for new_id, old_id_list in db.get_json_key(f"eol_rebase").items():
+    for new_id, old_id_list in db.get_json_key("eol_rebase").items():
         if appid in old_id_list:
             return new_id
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -148,6 +148,16 @@ def get_developer(
     return [app for app in result if app]
 
 
+@app.get("/eol/rebase")
+def get_eol_rebase():
+    return db.get_json_key(f"eol:rebase")
+
+
+@app.get("/eol/oldid")
+def get_eol_rebase():
+    return db.get_json_key(f"eol:oldid")
+
+
 @app.get("/projectgroup")
 def get_project_groups():
     return db.get_project_groups()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -148,12 +148,18 @@ def get_developer(
     return [app for app in result if app]
 
 
+@app.get("/eol/rebase")
+def get_eol_rebase_appid():
+    return db.get_json_key(f"eol_rebase")
+
+
 @app.get("/eol/rebase/{appid}")
-def get_eol_rebase(
+def get_eol_rebase_appid(
     appid: str,
 ):
-    if value := db.get_json_key(f"eol_rebase:{appid}"):
-        return value
+    for new_id, old_id_list in db.get_json_key(f"eol_rebase").items():
+        if appid in old_id_list:
+            return new_id
 
     return None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -148,14 +148,14 @@ def get_developer(
     return [app for app in result if app]
 
 
-@app.get("/eol/rebase")
-def get_eol_rebase():
-    return db.get_json_key(f"eol:rebase")
+@app.get("/eol/rebase/{appid}")
+def get_eol_rebase(
+    appid: str,
+):
+    if value := db.get_json_key(f"eol_rebase:{appid}"):
+        return value
 
-
-@app.get("/eol/oldid")
-def get_eol_rebase():
-    return db.get_json_key(f"eol:oldid")
+    return None
 
 
 @app.get("/projectgroup")

--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -182,8 +182,6 @@ def update():
         ):
             eol_rebase[eol_dict["eolr"].split("/")[1]] = [appid]
 
-    db.redis_conn.mset(
-        {f"eol_rebase": json.dumps(eol_rebase)}
-    )
+    db.redis_conn.mset({f"eol_rebase": json.dumps(eol_rebase)})
 
     return len(recently_updated_zset)

--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -182,6 +182,6 @@ def update():
         ):
             eol_rebase[eol_dict["eolr"].split("/")[1]] = [appid]
 
-    db.redis_conn.mset({f"eol_rebase": json.dumps(eol_rebase)})
+    db.redis_conn.mset({"eol_rebase": json.dumps(eol_rebase)})
 
     return len(recently_updated_zset)

--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -184,4 +184,8 @@ def update():
 
     db.redis_conn.mset({"eol_rebase": json.dumps(eol_rebase)})
 
+    for appid, old_id_list in eol_rebase.items():
+        for old_id in old_id_list:
+            db.redis_conn.mset({f"eol_rebase:{old_id}": json.dumps(appid)})
+
     return len(recently_updated_zset)

--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -180,7 +180,26 @@ def update():
             and not appid.endswith(".Locale")
             and not appid.endswith(".Sources")
         ):
-            eol_rebase[eol_dict["eolr"].split("/")[1]] = [appid]
+            new_id = eol_dict["eolr"].split("/")[1]
+            if new_id in eol_rebase:
+                eol_rebase[new_id].append(appid)
+            else:
+                eol_rebase[new_id] = [appid]
+
+    # Support changing of App ID multiple times
+    while True:
+        found = False
+        remove_list = []
+        for app_id, old_id_list in eol_rebase.items():
+            for new_app_id, check_id_list in eol_rebase.items():
+                if app_id in check_id_list:
+                    eol_rebase[new_app_id] += old_id_list
+                    remove_list.append(app_id)
+                    found = True
+        for i in remove_list:
+            del eol_rebase[i]
+        if not found:
+            break
 
     db.redis_conn.mset({"eol_rebase": json.dumps(eol_rebase)})
 

--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -171,4 +171,20 @@ def update():
         {f"summary:{appid}": json.dumps(summary_dict[appid]) for appid in summary_dict}
     )
 
+    eol_rebase = {}
+    for app, eol_dict in metadata["xa.sparse-cache"].items():
+        appid = app.split("/")[1]
+        if "eolr" in eol_dict and not appid.endswith(".Debug") and not appid.endswith(".Locale") and not appid.endswith(".Sources"):
+            eol_rebase[appid] = eol_dict["eolr"].split("/")[1]
+
+    old_apps = {}
+    for old_id, new_id in eol_rebase.items():
+        old_apps[new_id] = [old_id]
+
+    db.redis_conn.mset({
+        "eol:rebase": json.dumps(eol_rebase),
+        "eol:oldid": json.dumps(old_apps)
+    })
+
     return len(recently_updated_zset)
+    

--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -174,17 +174,16 @@ def update():
     eol_rebase = {}
     for app, eol_dict in metadata["xa.sparse-cache"].items():
         appid = app.split("/")[1]
-        if "eolr" in eol_dict and not appid.endswith(".Debug") and not appid.endswith(".Locale") and not appid.endswith(".Sources"):
+        if (
+            "eolr" in eol_dict
+            and not appid.endswith(".Debug")
+            and not appid.endswith(".Locale")
+            and not appid.endswith(".Sources")
+        ):
             eol_rebase[appid] = eol_dict["eolr"].split("/")[1]
 
-    old_apps = {}
-    for old_id, new_id in eol_rebase.items():
-        old_apps[new_id] = [old_id]
-
-    db.redis_conn.mset({
-        "eol:rebase": json.dumps(eol_rebase),
-        "eol:oldid": json.dumps(old_apps)
-    })
+    db.redis_conn.mset(
+        {f"eol_rebase:{appid}": json.dumps(eol_rebase[appid]) for appid in eol_rebase}
+    )
 
     return len(recently_updated_zset)
-    

--- a/backend/app/summary.py
+++ b/backend/app/summary.py
@@ -180,10 +180,10 @@ def update():
             and not appid.endswith(".Locale")
             and not appid.endswith(".Sources")
         ):
-            eol_rebase[appid] = eol_dict["eolr"].split("/")[1]
+            eol_rebase[eol_dict["eolr"].split("/")[1]] = [appid]
 
     db.redis_conn.mset(
-        {f"eol_rebase:{appid}": json.dumps(eol_rebase[appid]) for appid in eol_rebase}
+        {f"eol_rebase": json.dumps(eol_rebase)}
     )
 
     return len(recently_updated_zset)

--- a/frontend/pages/apps/details/[appDetails].tsx
+++ b/frontend/pages/apps/details/[appDetails].tsx
@@ -38,8 +38,8 @@ export default function Details({
 }) {
   const screenshots = app.screenshots
     ? app.screenshots.filter(pickScreenshot).map((screenshot: Screenshot) => ({
-      url: pickScreenshot(screenshot).url,
-    }))
+        url: pickScreenshot(screenshot).url,
+      }))
     : []
 
   return (

--- a/frontend/pages/apps/details/[appDetails].tsx
+++ b/frontend/pages/apps/details/[appDetails].tsx
@@ -9,6 +9,7 @@ import {
   fetchDeveloperApps,
   fetchProjectgroupApps,
   fetchVerificationStatus,
+  fetchEolRebase,
 } from "../../../src/fetchers"
 import { NextSeo } from "next-seo"
 import {
@@ -37,8 +38,8 @@ export default function Details({
 }) {
   const screenshots = app.screenshots
     ? app.screenshots.filter(pickScreenshot).map((screenshot: Screenshot) => ({
-        url: pickScreenshot(screenshot).url,
-      }))
+      url: pickScreenshot(screenshot).url,
+    }))
     : []
 
   return (
@@ -74,6 +75,16 @@ export const getStaticProps: GetStaticProps = async ({
   params: { appDetails: appId },
 }) => {
   console.log("Fetching data for app details: ", appId)
+  const eolRebaseTo = await fetchEolRebase(appId as string)
+
+  if (eolRebaseTo) {
+    return {
+      redirect: {
+        destination: `/apps/details/${eolRebaseTo}`,
+        permanent: true,
+      },
+    }
+  }
   const app = await fetchAppstream(appId as string)
   const summary = await fetchSummary(appId as string)
   const stats = await fetchAppStats(appId as string)

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -3,6 +3,8 @@ import { Category } from "./types/Category"
 const BASE_URI: string = process.env.NEXT_PUBLIC_API_BASE_URI
 
 export const APPSTREAM_URL: string = `${BASE_URI}/appstream`
+export const EOL_REBASE_URL = (id: string): string =>
+  `${BASE_URI}/eol/rebase/${id}`
 export const APP_DETAILS = (id: string): string => `${APPSTREAM_URL}/${id}`
 export const SUMMARY_DETAILS = (id: string): string =>
   `${BASE_URI}/summary/${id}`

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -17,6 +17,7 @@ import {
   PROJECTGROUP_URL,
   LOGIN_PROVIDERS_URL,
   VENDING_CONFIG_URL,
+  EOL_REBASE_URL,
   APP_VERIFICATION_STATUS,
   APP_VERIFICATION_AVAILABLE_METHODS,
 } from "./env"
@@ -38,6 +39,23 @@ export async function fetchAppstream(appId: string): Promise<Appstream> {
 
   if (!entryJson) {
     console.log(`No appstream data for ${appId}`)
+  }
+  return entryJson
+}
+
+export async function fetchEolRebase(
+  appId: string,
+): Promise<string | undefined> {
+  let entryJson: string | undefined
+  try {
+    const entryData = await fetch(`${EOL_REBASE_URL(appId)}`)
+    entryJson = await entryData.json()
+  } catch (error) {
+    console.log(error)
+  }
+
+  if (!entryJson) {
+    console.log(`No eol rebase data`)
   }
   return entryJson
 }
@@ -124,8 +142,7 @@ export default async function fetchCollection(
   const limitedList = collectionList.slice(0, limit)
 
   console.log(
-    `\nCollection ${collection} fetched. Asked for: ${count}. Returned items: ${
-      limitedList.filter((item) => Boolean(item)).length
+    `\nCollection ${collection} fetched. Asked for: ${count}. Returned items: ${limitedList.filter((item) => Boolean(item)).length
     }.`,
   )
 
@@ -141,8 +158,7 @@ export async function fetchCategory(
   const appList = await appListRes.json()
 
   console.log(
-    `\nCategory ${category} fetched. Asked for Page: ${page} with ${per_page} per page. Returned items: ${
-      appList.filter((item) => Boolean(item)).length
+    `\nCategory ${category} fetched. Asked for Page: ${page} with ${per_page} per page. Returned items: ${appList.filter((item) => Boolean(item)).length
     }.`,
   )
 

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -142,7 +142,8 @@ export default async function fetchCollection(
   const limitedList = collectionList.slice(0, limit)
 
   console.log(
-    `\nCollection ${collection} fetched. Asked for: ${count}. Returned items: ${limitedList.filter((item) => Boolean(item)).length
+    `\nCollection ${collection} fetched. Asked for: ${count}. Returned items: ${
+      limitedList.filter((item) => Boolean(item)).length
     }.`,
   )
 
@@ -158,7 +159,8 @@ export async function fetchCategory(
   const appList = await appListRes.json()
 
   console.log(
-    `\nCategory ${category} fetched. Asked for Page: ${page} with ${per_page} per page. Returned items: ${appList.filter((item) => Boolean(item)).length
+    `\nCategory ${category} fetched. Asked for Page: ${page} with ${per_page} per page. Returned items: ${
+      appList.filter((item) => Boolean(item)).length
     }.`,
   )
 


### PR DESCRIPTION
This PR adds a API for a EOL rebase (Apps changing their ID),

There are 2 new endpoints:
/eol/rebase: A simple dict, which shows which App has a EOL rebase
/eol/oldid: Returns a list with all old ids of a App. At the moment, there is no App that changed the ID more than once, so the implementation is currently simple.