### PR TITLE
Password Safe is now called Secrets

### DIFF
--- a/backend/data/picks/apps.json
+++ b/backend/data/picks/apps.json
@@ -22,7 +22,7 @@
   "org.gnome.Builder",
   "org.gnome.Connections",
   "org.gnome.Lollypop",
-  "org.gnome.PasswordSafe",
+  "org.gnome.World.Secrets",
   "org.gnome.Solanum",
   "org.gnome.World.PikaBackup",
   "org.gnome.design.Contrast",


### PR DESCRIPTION
This problem affects both stable and beta website.
Editor Choice is suggesting Password Safe, which is several versions behind Secrets:

- https://flathub.org/apps/details/org.gnome.PasswordSafe
- https://flathub.org/apps/details/org.gnome.World.Secrets
