### PR TITLE
Encode urls when searching to prevent 404s

### DIFF
--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -1,5 +1,6 @@
-import meilisearch
 from urllib.parse import unquote
+
+import meilisearch
 
 from . import config
 

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -1,4 +1,5 @@
 import meilisearch
+from urllib.parse import unquote
 
 from . import config
 
@@ -31,6 +32,8 @@ def delete_apps(app_id_list):
 
 
 def search_apps(query: str):
+    query = unquote(query)
+
     if results := client.index("apps").search(
         query, {"limit": 250, "sort": ["downloads_last_month:desc"]}
     ):

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -75,7 +75,7 @@ const Header = () => {
     e.preventDefault()
     const disallowedQueries = ["", ".", ".."]
     if (!disallowedQueries.includes(query)) {
-      const queryEncoded = encodeURIComponent(query).replace(".", "%2E")
+      const queryEncoded = encodeURIComponent(query).replace(/\./g, "%2E")
       router.push(`/apps/search/${queryEncoded}`)
     }
   }

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -74,7 +74,8 @@ const Header = () => {
   const onSubmit = (e: ChangeEvent<HTMLFormElement>) => {
     e.preventDefault()
     if (query !== "") {
-      router.push(`/apps/search/${query}`)
+      const queryEncoded = encodeURIComponent(query)
+      router.push(`/apps/search/${queryEncoded}`)
     }
   }
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -73,8 +73,9 @@ const Header = () => {
 
   const onSubmit = (e: ChangeEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (query !== "") {
-      const queryEncoded = encodeURIComponent(query)
+    const disallowedQueries = ["", ".", ".."]
+    if (!disallowedQueries.includes(query)) {
+      const queryEncoded = encodeURIComponent(query).replace(".", "%2E")
       router.push(`/apps/search/${queryEncoded}`)
     }
   }

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -196,10 +196,11 @@ export async function fetchProjectgroupApps(projectgroup: string | undefined) {
 }
 
 export async function fetchSearchQuery(query: string) {
-  const appListRes = await fetch(SEARCH_APP(query))
+  const queryEncoded = encodeURIComponent(query)
+  const appListRes = await fetch(SEARCH_APP(queryEncoded))
   const appList = await appListRes.json()
 
-  console.log(`\nSearch for query: ${query} fetched`)
+  console.log(`\nSearch for query: ${queryEncoded} fetched`)
 
   return appList.filter((item) => Boolean(item))
 }

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -196,7 +196,7 @@ export async function fetchProjectgroupApps(projectgroup: string | undefined) {
 }
 
 export async function fetchSearchQuery(query: string) {
-  const queryEncoded = encodeURIComponent(query)
+  const queryEncoded = encodeURIComponent(query).replace(".", "%2E")
   const appListRes = await fetch(SEARCH_APP(queryEncoded))
   const appList = await appListRes.json()
 

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -196,7 +196,7 @@ export async function fetchProjectgroupApps(projectgroup: string | undefined) {
 }
 
 export async function fetchSearchQuery(query: string) {
-  const queryEncoded = encodeURIComponent(query).replace(".", "%2E")
+  const queryEncoded = encodeURIComponent(query).replace(/\./g, "%2E")
   const appListRes = await fetch(SEARCH_APP(queryEncoded))
   const appList = await appListRes.json()
 


### PR DESCRIPTION
Fix for https://github.com/flathub/website/issues/378
Old PR was https://github.com/flathub/website/pull/707

Hello, looks like the old PR closed itself when I swapped branch. Sorry for the noise.

I have added manual encoding of a `.`, since encodeURIComponent doesn't do it.

A search like "gitlab.com" works for me, but a search of just `.` or `..` was causing a NormalizeError, so I added them to an exclusion list, as I wouldn't think they would be useful searches anyway.