### PR TITLE
purchases: Fix download token

### DIFF
--- a/backend/app/purchases.py
+++ b/backend/app/purchases.py
@@ -155,7 +155,7 @@ def get_download_token(appids: List[str], update_token: str = Body(None)):
         {
             "sub": "download",
             "exp": datetime.utcnow() + timedelta(hours=24),
-            "repos": appids,
+            "apps": appids,
         },
         base64.b64decode(config.settings.flat_manager_secret),
         algorithm="HS256",


### PR DESCRIPTION
"repos" is not the correct field for app IDs. It should be "apps", which is added in <https://github.com/flatpak/flat-manager/pull/77>.