### PR TITLE
backend: Republish app when vending config changes

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -46,9 +46,18 @@ class Settings(BaseSettings):
     stripe_secret_key: Optional[str] = None
     stripe_public_key: Optional[str] = None
     stripe_webhook_key: Optional[str] = None
-    flat_manager_secret: str = "c2VjcmV0"
-    update_token_secret: str = "c2VjcmV0"
     env: str = "production"
+
+    # Should match "repo-secret" in flat-manager's config
+    flat_manager_secret: str = "c2VjcmV0"
+    # Should be a unique random secret, not in flat-manager's config
+    update_token_secret: str = "c2VjcmV0"
+    # Should match "secret" in flat-manager's config
+    flat_manager_build_secret: Optional[str] = "c2VjcmV0"
+    # The URL for flat-manager. If present, the backend will use it to queue republish jobs when storefront info
+    # changes. To test in development, set the environment variable FLAT_MANAGER_API=http://host.docker.internal:8080
+    # when running docker-compose.
+    flat_manager_api: Optional[str] = None
 
 
 settings = Settings()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,3 +1,4 @@
+import base64
 import os
 from typing import Optional
 
@@ -49,11 +50,15 @@ class Settings(BaseSettings):
     env: str = "production"
 
     # Should match "repo-secret" in flat-manager's config
-    flat_manager_secret: str = "c2VjcmV0"
+    flat_manager_secret: str = base64.b64encode("secret".encode("utf-8")).decode()
     # Should be a unique random secret, not in flat-manager's config
-    update_token_secret: str = "c2VjcmV0"
+    update_token_secret: str = base64.b64encode(
+        "update_token_secret".encode("utf-8")
+    ).decode()
     # Should match "secret" in flat-manager's config
-    flat_manager_build_secret: Optional[str] = "c2VjcmV0"
+    flat_manager_build_secret: Optional[str] = base64.b64encode(
+        "secret".encode("utf-8")
+    ).decode()
     # The URL for flat-manager. If present, the backend will use it to queue republish jobs when storefront info
     # changes. To test in development, set the environment variable FLAT_MANAGER_API=http://host.docker.internal:8080
     # when running docker-compose.

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       - STATS_BASEURL=${STATS_BASEURL-https://flathub.org/stats}
       - APPSTREAM_REPOS=$APPSTREAM_REPOS
       - DATADIR=${DATADIR-/app/data}
+      - FLAT_MANAGER_API=$FLAT_MANAGER_API
     depends_on:
       - redis
       - db
@@ -57,6 +58,9 @@ services:
     volumes:
       - /var/lib/flatpak
       - .:/app:z
+    # The workers need access to flat-manager, which is a separate repository and usually runs on the host.
+    extra_hosts:
+      host.docker.internal: host-gateway
 
   db:
     image: docker.io/library/postgres:14


### PR DESCRIPTION
Add a configuration option for the flat-manager build secret and API endpoint. When an app's vending configuration is changed, flat-manager is notified to re-publish the app's commits in both the stable and beta repos.