### PR TITLE
Bring back app types

### DIFF
--- a/backend/app/apps.py
+++ b/backend/app/apps.py
@@ -11,34 +11,39 @@ def load_appstream():
     current_categories = db.redis_conn.smembers("categories:index")
     current_developers = db.redis_conn.smembers("developers:index")
     current_projectgroups = db.redis_conn.smembers("developers:projectgroups")
+    current_types = db.redis_conn.smembers("types:index")
 
     with db.redis_conn.pipeline() as p:
         p.delete("categories:index", *current_categories)
         p.delete("developers:index", *current_developers)
         p.delete("projectgroups:index", *current_projectgroups)
+        p.delete("types:index", *current_types)
 
         clean_html_re = re.compile("<.*?>")
         search_apps = []
         for appid in apps:
             redis_key = f"apps:{appid}"
 
-            search_description = re.sub(clean_html_re, "", apps[appid]["description"])
+            if apps[appid].get("type") == "desktop":
+                search_description = re.sub(
+                    clean_html_re, "", apps[appid]["description"]
+                )
 
-            search_keywords = apps[appid].get("keywords")
+                search_keywords = apps[appid].get("keywords")
 
-            # order of the dict is important for attritbute ranking
-            search_apps.append(
-                {
-                    "id": utils.get_clean_app_id(appid),
-                    "name": apps[appid]["name"],
-                    "summary": apps[appid]["summary"],
-                    "downloads_last_month": 0,
-                    "keywords": search_keywords,
-                    "app_id": appid,
-                    "description": search_description,
-                    "icon": apps[appid]["icon"],
-                }
-            )
+                # order of the dict is important for attritbute ranking
+                search_apps.append(
+                    {
+                        "id": utils.get_clean_app_id(appid),
+                        "name": apps[appid]["name"],
+                        "summary": apps[appid]["summary"],
+                        "downloads_last_month": 0,
+                        "keywords": search_keywords,
+                        "app_id": appid,
+                        "description": search_description,
+                        "icon": apps[appid]["icon"],
+                    }
+                )
 
             if developer_name := apps[appid].get("developer_name"):
                 p.sadd("developers:index", developer_name)
@@ -49,6 +54,10 @@ def load_appstream():
                 p.sadd(f"projectgroups:{project_group}", redis_key)
 
             p.set(f"apps:{appid}", json.dumps(apps[appid]))
+
+            if type := apps[appid].get("type"):
+                p.sadd("types:index", type)
+                p.sadd(f"types:{type}", redis_key)
 
             if categories := apps[appid].get("categories"):
                 for category in categories:
@@ -78,8 +87,11 @@ def load_appstream():
     return new_apps
 
 
-def list_appstream():
-    apps = {app[5:] for app in db.redis_conn.smembers("apps:index")}
+def list_appstream(type: schemas.Type = schemas.Type.Desktop):
+    if type == "all":
+        apps = {app[5:] for app in db.redis_conn.smembers("apps:index")}
+    else:
+        apps = {app[5:] for app in db.redis_conn.smembers(f"types:{type.value}")}
     return sorted(apps)
 
 

--- a/backend/app/compat.py
+++ b/backend/app/compat.py
@@ -50,7 +50,7 @@ def get_short_app(key: str):
     return compat_app
 
 
-def list_apps_in_index(index="apps:index"):
+def list_apps_in_index(index="types:desktop"):
     appids = sorted(db.redis_conn.smembers(index))
     ret = []
 
@@ -161,6 +161,9 @@ def get_search(query: str):
 @router.get("/apps/{appid}")
 def get_single_app(appid: str, background_tasks: BackgroundTasks):
     if app := db.get_json_key(f"apps:{appid}"):
+        if app.get("type") != "desktop":
+            return Response(status_code=404)
+
         compat_app = {
             "flatpakAppId": appid,
             "name": app.get("name"),

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -3,7 +3,7 @@ import time
 import orjson
 import redis
 
-from . import config
+from . import config, schemas
 
 redis_conn = redis.Redis(
     db=config.settings.redis_db,
@@ -42,6 +42,13 @@ def get_json_key(key: str):
 
 def get_categories():
     return {category for category in redis_conn.smembers("categories:index")}
+
+
+def get_app_count(type: schemas.Type = schemas.Type.Desktop) -> int:
+    if type == schemas.Type.All:
+        return redis_conn.scard("apps:index")
+    else:
+        return redis_conn.scard(f"types:{type.value}")
 
 
 def get_developers():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -163,14 +163,15 @@ def get_project_group(
 
 
 @app.get("/appstream")
-def list_appstream():
-    return apps.list_appstream()
+def list_appstream(type: schemas.Type = schemas.Type.Desktop):
+    return apps.list_appstream(type)
 
 
 @app.get("/appstream/{appid}", status_code=200)
 def get_appstream(appid: str, response: Response):
     if value := db.get_json_key(f"apps:{appid}"):
-        return value
+        if value.get("type") == "desktop":
+            return value
 
     response.status_code = 404
     return None

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -14,3 +14,13 @@ class Category(str, Enum):
     Science = "Science"
     System = "System"
     Utility = "Utility"
+
+
+class Type(str, Enum):
+    All = "all"
+    Addon = "addon"
+    ConsoleApplication = "console-application"
+    Desktop = "desktop"
+    Generic = "generic"
+    Inputmethod = "inputmethod"
+    Runtime = "runtime"

--- a/backend/app/stats.py
+++ b/backend/app/stats.py
@@ -9,12 +9,14 @@ import requests
 
 from app import utils
 
-from . import config, db, search
+from . import config, db, schemas, search
 
 StatsType = Dict[str, Dict[str, List[int]]]
 POPULAR_DAYS_NUM = 7
 
 FIRST_STATS_DATE = datetime.date(2018, 4, 29)
+
+THREAD_POOL = 16
 
 
 def _get_stats_for_date(date: datetime.date, session: requests.Session):
@@ -46,52 +48,52 @@ def _get_stats_for_date(date: datetime.date, session: requests.Session):
     return stats
 
 
-def _get_stats_for_period(sdate: datetime.date, edate: datetime.date):
+def _get_stats_for_period(
+    sdate: datetime.date, edate: datetime.date, session: requests.Session
+) -> StatsType:
     totals: StatsType = {}
-    with requests.Session() as session:
-        for i in range((edate - sdate).days + 1):
-            date = sdate + datetime.timedelta(days=i)
-            stats = _get_stats_for_date(date, session)
 
-            if stats is None or "refs" not in stats or stats["refs"] is None:
-                continue
-            for app_id, app_stats in stats["refs"].items():
-                if app_id not in totals:
-                    totals[app_id] = {}
-                app_totals = totals[app_id]
-                for arch, downloads in app_stats.items():
-                    if arch not in app_totals:
-                        app_totals[arch] = [0, 0, 0]
-                    app_totals[arch][0] += downloads[0]
-                    app_totals[arch][1] += downloads[1]
-                    app_totals[arch][2] += downloads[0] - downloads[1]
+    for i in range((edate - sdate).days + 1):
+        date = sdate + datetime.timedelta(days=i)
+        stats = _get_stats_for_date(date, session)
+
+        if stats is None or "refs" not in stats or stats["refs"] is None:
+            continue
+        for app_id, app_stats in stats["refs"].items():
+            if app_id not in totals:
+                totals[app_id] = {}
+            app_totals = totals[app_id]
+            for arch, downloads in app_stats.items():
+                if arch not in app_totals:
+                    app_totals[arch] = [0, 0, 0]
+                app_totals[arch][0] += downloads[0]
+                app_totals[arch][1] += downloads[1]
+                app_totals[arch][2] += downloads[0] - downloads[1]
     return totals
 
 
-def _get_app_stats_per_day() -> Dict[str, Dict[str, int]]:
+def _get_app_stats_per_day(session: requests.Session) -> Dict[str, Dict[str, int]]:
     # Skip last two days as flathub-stats publishes partial statistics
     edate = datetime.date.today() - datetime.timedelta(days=2)
     sdate = FIRST_STATS_DATE
 
     app_stats_per_day: Dict[str, Dict[str, int]] = {}
 
-    with requests.Session() as session:
-        for i in range((edate - sdate).days + 1):
-            date = sdate + datetime.timedelta(days=i)
-            stats = _get_stats_for_date(date, session)
+    for i in range((edate - sdate).days + 1):
+        date = sdate + datetime.timedelta(days=i)
+        stats = _get_stats_for_date(date, session)
 
-            if stats is not None and "refs" in stats and stats["refs"] is not None:
-                for app_id, app_stats in stats["refs"].items():
-                    if _is_app(app_id):
-                        if app_id not in app_stats_per_day:
-                            app_stats_per_day[app_id] = {}
-                        app_stats_per_day[app_id][date.isoformat()] = sum(
-                            [i[0] - i[1] for i in app_stats.values()]
-                        )
+        if stats is not None and "refs" in stats and stats["refs"] is not None:
+            for app_id, app_stats in stats["refs"].items():
+                if app_id not in app_stats_per_day:
+                    app_stats_per_day[app_id] = {}
+                app_stats_per_day[app_id][date.isoformat()] = sum(
+                    [i[0] - i[1] for i in app_stats.values()]
+                )
     return app_stats_per_day
 
 
-def _get_stats(app_count: int) -> Dict[str, Dict[str, int]]:
+def _get_stats(session: requests.Session) -> Dict[str, Dict[str, int]]:
     edate = datetime.date.today()
     sdate = FIRST_STATS_DATE
 
@@ -99,41 +101,39 @@ def _get_stats(app_count: int) -> Dict[str, Dict[str, int]]:
     delta_downloads_per_day: Dict[str, int] = {}
     updates_per_day: Dict[str, int] = {}
     totals_country: Dict[str, int] = {}
-    with requests.Session() as session:
-        for i in range((edate - sdate).days + 1):
-            date = sdate + datetime.timedelta(days=i)
-            stats = _get_stats_for_date(date, session)
 
-            if (
-                stats is not None
-                and "downloads" in stats
-                and stats["downloads"] is not None
-            ):
-                downloads_per_day[date.isoformat()] = stats["downloads"]
+    app_count = db.get_app_count(type=schemas.Type.Desktop)
 
-            if (
-                stats is not None
-                and "updates" in stats
-                and stats["updates"] is not None
-            ):
-                updates_per_day[date.isoformat()] = stats["updates"]
+    for i in range((edate - sdate).days + 1):
+        date = sdate + datetime.timedelta(days=i)
+        stats = _get_stats_for_date(date, session)
 
-            if (
-                stats is not None
-                and "delta_downloads" in stats
-                and stats["delta_downloads"] is not None
-            ):
-                delta_downloads_per_day[date.isoformat()] = stats["delta_downloads"]
+        if (
+            stats is not None
+            and "downloads" in stats
+            and stats["downloads"] is not None
+        ):
+            downloads_per_day[date.isoformat()] = stats["downloads"]
 
-            if (
-                stats is not None
-                and "countries" in stats
-                and stats["countries"] is not None
-            ):
-                for country, downloads in stats["countries"].items():
-                    if country not in totals_country:
-                        totals_country[country] = 0
-                    totals_country[country] = totals_country[country] + downloads
+        if stats is not None and "updates" in stats and stats["updates"] is not None:
+            updates_per_day[date.isoformat()] = stats["updates"]
+
+        if (
+            stats is not None
+            and "delta_downloads" in stats
+            and stats["delta_downloads"] is not None
+        ):
+            delta_downloads_per_day[date.isoformat()] = stats["delta_downloads"]
+
+        if (
+            stats is not None
+            and "countries" in stats
+            and stats["countries"] is not None
+        ):
+            for country, downloads in stats["countries"].items():
+                if country not in totals_country:
+                    totals_country[country] = 0
+                totals_country[country] = totals_country[country] + downloads
     return {
         "countries": totals_country,
         "downloads_per_day": downloads_per_day,
@@ -162,8 +162,6 @@ def _is_app(app_id: str) -> bool:
 def get_installs_by_ids(ids: List[str]):
     result = defaultdict()
     for app_id in ids:
-        if not _is_app(app_id):
-            continue
         app_stats = db.get_json_key(f"app_stats:{app_id}")
         if app_stats is None:
             continue
@@ -184,7 +182,16 @@ def get_popular(days: Optional[int]):
     if popular := db.get_json_key(redis_key):
         return popular
 
-    stats = _get_stats_for_period(sdate, edate)
+    with requests.Session() as session:
+        session.mount(
+            "https://",
+            requests.adapters.HTTPAdapter(
+                pool_maxsize=THREAD_POOL, max_retries=3, pool_block=True
+            ),
+        )
+
+        stats = _get_stats_for_period(sdate, edate, session)
+
     sorted_apps = sorted(
         filter(lambda a: _is_app(a[0]), stats.items()),
         key=lambda a: _sort_key(a[1]),
@@ -202,32 +209,51 @@ def update(all_app_ids: list):
     edate = datetime.date.today()
     sdate = datetime.date(2018, 4, 29)
 
-    stats_total = _get_stats_for_period(sdate, edate)
-    stats_dict = _get_stats(len(all_app_ids))
+    with requests.Session() as session:
+        session.mount(
+            "https://",
+            requests.adapters.HTTPAdapter(
+                pool_maxsize=THREAD_POOL, max_retries=3, pool_block=True
+            ),
+        )
 
-    app_stats_per_day = _get_app_stats_per_day()
+        stats_total = _get_stats_for_period(sdate, edate, session)
+
+        stats_dict = _get_stats(session)
+
+        app_stats_per_day = _get_app_stats_per_day(session)
+
+        sdate_30_days = edate - datetime.timedelta(days=30 - 1)
+        stats_30_days = _get_stats_for_period(sdate_30_days, edate, session)
+
+        sdate_7_days = edate - datetime.timedelta(days=7 - 1)
+        stats_7_days = _get_stats_for_period(sdate_7_days, edate, session)
 
     for appid, dict in stats_total.items():
-        if _is_app(appid):
-            # Index 0 is install and update count index 1 would be the update count
-            # Index 2 is the install count
-            stats_apps_dict[appid]["installs_total"] = sum(
-                [i[2] for i in dict.values()]
-            )
+        # Remove /stable from the end of appid
+        if appid.endswith("/stable"):
+            appid = appid[:-7]
 
-            if appid in app_stats_per_day:
-                stats_apps_dict[appid]["installs_per_day"] = app_stats_per_day[appid]
+        # Index 0 is install and update count index 1 would be the update count
+        # Index 2 is the install count
+        stats_apps_dict[appid]["installs_total"] = sum([i[2] for i in dict.values()])
 
-    sdate_30_days = edate - datetime.timedelta(days=30 - 1)
-    stats_30_days = _get_stats_for_period(sdate_30_days, edate)
+        if appid in app_stats_per_day:
+            stats_apps_dict[appid]["installs_per_day"] = app_stats_per_day[appid]
 
     stats_installs: List = []
     for appid, dict in stats_30_days.items():
+        # Remove /stable from the end of appid
+        if appid.endswith("/stable"):
+            appid = appid[:-7]
+
+        # Index 0 is install and update count index 1 would be the update count
+        # Index 2 is the install count
+        installs_last_month = sum([i[2] for i in dict.values()])
+        stats_apps_dict[appid]["installs_last_month"] = installs_last_month
+
+        # Only add normal apps to the search index
         if _is_app(appid):
-            # Index 0 is install and update count index 1 would be the update count
-            # Index 2 is the install count
-            installs_last_month = sum([i[2] for i in dict.values()])
-            stats_apps_dict[appid]["installs_last_month"] = installs_last_month
             if appid in all_app_ids:
                 stats_installs.append(
                     {
@@ -237,16 +263,16 @@ def update(all_app_ids: list):
                 )
     search.update_apps(stats_installs)
 
-    sdate_7_days = edate - datetime.timedelta(days=7 - 1)
-    stats_7_days = _get_stats_for_period(sdate_7_days, edate)
-
     for appid, dict in stats_7_days.items():
-        if _is_app(appid):
-            # Index 0 is install and update count index 1 would be the update count
-            # Index 2 is the install count
-            stats_apps_dict[appid]["installs_last_7_days"] = sum(
-                [i[2] for i in dict.values()]
-            )
+        # Remove /stable from the end of appid
+        if appid.endswith("/stable"):
+            appid = appid[:-7]
+
+        # Index 0 is install and update count index 1 would be the update count
+        # Index 2 is the install count
+        stats_apps_dict[appid]["installs_last_7_days"] = sum(
+            [i[2] for i in dict.values()]
+        )
 
     db.redis_conn.set("stats", orjson.dumps(stats_dict))
     db.redis_conn.mset(

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -64,8 +64,7 @@ def appstream2dict(reponame: str):
     for component in root:
         app = {}
 
-        if component.attrib.get("type") != "desktop":
-            continue
+        app["type"] = component.attrib.get("type")
 
         descriptions = component.findall("description")
         if len(descriptions):

--- a/backend/tests/results/test_appstream_by_appid.json
+++ b/backend/tests/results/test_appstream_by_appid.json
@@ -1,4 +1,5 @@
 {
+  "type": "desktop",
   "description": "<p>Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.</p>",
   "screenshots": [
     {
@@ -42,8 +43,12 @@
   "name": "Maze",
   "summary": "A simple maze game",
   "developer_name": "Sugar Labs Community",
-  "categories": ["Game"],
-  "kudos": ["HiDpiIcon"],
+  "categories": [
+    "Game"
+  ],
+  "kudos": [
+    "HiDpiIcon"
+  ],
   "project_license": "GPL-3.0-or-later",
   "project_group": "SugarLabs",
   "launchable": {


### PR DESCRIPTION
This allows to store data from other app types like plugins or console apps.

Right now it's not used in the frontend, but it could be queried from the stats endpoint.

Basically a reworked revert of https://github.com/flathub/website/commit/c9443fc7de65e9802f104d470e65db11e8e2dfd7