### PR TITLE
verification: De-mangle domain name in app IDs

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -342,3 +342,21 @@ def _load_platforms(with_stripe: bool) -> Dict[str, Platform]:
 
 PLATFORMS = _load_platforms(False)
 PLATFORMS_WITH_STRIPE = _load_platforms(True)
+
+
+def is_valid_app_id(appid: str) -> bool:
+    """Ensures that an app ID is correctly formed. The requirements are taken from the D-Bus spec for well-known bus
+    names [1], except we require at least 3 segments rather than 2.
+
+    [1] https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus"""
+
+    if len(appid) > 255:
+        return False
+
+    elements = appid.split(".")
+    if len(elements) < 3:
+        return False
+    for element in elements:
+        if not re.match(r"^[A-Za-z_][\w\-]*$", element):
+            return False
+    return True

--- a/backend/tests/main.py
+++ b/backend/tests/main.py
@@ -380,6 +380,35 @@ def test_compat_apps_recently_updated(client):
     assert response_json == expected_json
 
 
+def test_valid_app_ids():
+    from app.utils import is_valid_app_id
+
+    assert is_valid_app_id("org.gnome.Maps")
+    assert is_valid_app_id("a.b.c.d.e")
+    assert is_valid_app_id("a.b-c.d")
+
+    assert not is_valid_app_id("com.example")
+    assert not is_valid_app_id("..")
+    assert not is_valid_app_id("a..c")
+    assert not is_valid_app_id("com.7zip.7zip")
+    assert not is_valid_app_id("com.example." + ("A" * 255))
+
+
+def test_verification_domain_names():
+    from app.verification import _get_domain_name
+
+    assert _get_domain_name("com.github.Example") is None
+    assert _get_domain_name("com.gitlab.Example") is None
+
+    assert _get_domain_name("io.github.example.App") == "example.github.io"
+    assert _get_domain_name("io.gitlab.example.App") == "example.gitlab.io"
+
+    assert _get_domain_name("org.flathub.TestApp") == "flathub.org"
+    assert _get_domain_name("org._0example.TestApp") == "0example.org"
+    assert _get_domain_name("org.example_website.TestApp") == "example-website.org"
+    assert _get_domain_name("org._0_example.TestApp") == "0-example.org"
+
+
 @vcr.use_cassette()
 def test_verification_status(client):
     response = client.get("/verification/com.github.flathub.ExampleApp/status")


### PR DESCRIPTION
Flatpak app IDs are slightly more restrictive than domain names, so some mangling is required. Fortunately, given [the syntax for domain name labels](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.1), the prescribed mangling rules are reversible.

[Mangling rules](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-names-bus):
- If an element starts with a digit, which is not allowed in D-Bus, prefix it with an underscore.
- Replace hyphens with underscores, since hyphens are not allowed in D-Bus.

Domain names may not contain underscores, so any underscore in an app ID is the result of mangling. Hyphens are not permitted as the first character of a domain name, so an underscore there is always escaping a digit. Only a digit as the first character must be escaped as such, so an underscore anywhere else is always replacing a hyphen.

Also, updated the logic in `is_valid_app_id()` to more closely match the D-Bus specification.