### PR TITLE
Allow apps with no releases

### DIFF
--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -128,7 +128,7 @@ const Details: FunctionComponent<Props> = ({
     const moreThan1Screenshot =
       app.screenshots?.filter(pickScreenshot).length > 1
 
-    const stableReleases = app.releases.filter(
+    const stableReleases = app.releases?.filter(
       (release) => release.type === undefined || release.type === "stable",
     )
 


### PR DESCRIPTION
For some reasons, some apps don't have releases currently. This change allows us to still show those pages.