### PR TITLE
fix(frontend): use callbacks to sign in and out

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -399,7 +399,7 @@ const Header = () => {
                         <button
                           key={"logout"}
                           onClick={() => {
-                            setClickedLogout(true)
+                            onLogout()
                             close()
                           }}
                           className="block w-full rounded-md py-2 px-3 text-left text-base font-medium text-white hover:bg-colorHighlight dark:text-textPrimary"

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from "react"
+import { ChangeEvent, useCallback, useEffect, useState } from "react"
 import Link from "next/link"
 import { useRouter } from "next/router"
 import { HiMagnifyingGlass, HiXMark, HiBars3 } from "react-icons/hi2"
@@ -38,19 +38,21 @@ const Header = () => {
 
   const [query, setQuery] = useState("")
 
-  // Using state to prevent user repeatedly initiating fetches
   const [clickedLogout, setClickedLogout] = useState(false)
   const dispatch = useUserDispatch()
 
-  // Only make a request on first logout click
-  useEffect(() => {
-    if (clickedLogout) {
-      logout(dispatch).catch((err) => {
-        toast.error(t(err))
-        setClickedLogout(false)
-      })
+  const onLogout = useCallback(async () => {
+    // Only make a request on first logout click
+    if (clickedLogout) return
+    setClickedLogout(true)
+
+    try {
+      logout(dispatch)
+    } catch (err) {
+      toast.error(t(err))
+      setClickedLogout(false)
     }
-  }, [dispatch, clickedLogout, t])
+  }, [clickedLogout, dispatch, t])
 
   useEffect(() => {
     document.dir = i18n.dir()
@@ -274,9 +276,7 @@ const Header = () => {
                           <Menu.Item key="logout">
                             {({ active }) => (
                               <button
-                                onClick={() => {
-                                  setClickedLogout(true)
-                                }}
+                                onClick={onLogout}
                                 className={classNames(
                                   active ? "bg-gray-100" : "",
                                   "block w-full py-2 px-4 text-left text-sm font-normal text-gray-700 hover:bg-white hover:opacity-75",


### PR DESCRIPTION
I've called this a fix as the previous pattern I'd used here was misusing the `useEffect` hook. To the end user the result appears the same, but semantically it makes much more sense to directly call these from the user input event with a callback. Technically this removes some unnecessary calls to the previous effect code when the components first mount, but that's admittedly negligible.