### PR TITLE
Change app card to show the summary and app name next to it instead o…

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "@storybook/manager-webpack5": "^6.5.14",
     "@storybook/react": "^6.5.14",
     "@storybook/testing-library": "^0.0.13",
+    "@tailwindcss/line-clamp": "^0.4.2",
     "@tailwindcss/typography": "^0.5.8",
     "@types/node": "^18.11.4",
     "@types/react": "^17.0.43",

--- a/frontend/src/components/application/ApplicationCard.tsx
+++ b/frontend/src/components/application/ApplicationCard.tsx
@@ -12,18 +12,18 @@ const ApplicationCard: FunctionComponent<Props> = ({ application }) => (
   <Link
     href={`/apps/details/${application.id}`}
     passHref
-    className="flex min-w-0 flex-col rounded-xl bg-bgColorSecondary shadow-md duration-500 hover:cursor-pointer hover:no-underline hover:shadow-xl hover:brightness-95 active:bg-bgColorPrimary"
+    className="flex h-[160px] min-w-0 gap-4 rounded-xl bg-bgColorSecondary p-4 shadow-md duration-500 hover:cursor-pointer hover:no-underline hover:shadow-xl hover:brightness-95 active:bg-bgColorPrimary"
   >
-    <div className="flex h-[168px] items-center justify-center drop-shadow-md">
+    <div className="flex h-[128px] flex-shrink-0 flex-wrap items-center justify-center drop-shadow-md">
       <LogoImage iconUrl={application.icon} appName={application.name} />
     </div>
-    <div className="flex h-16 w-full flex-col justify-center px-4 pt-0 pb-1 text-center">
-      <h4 className="m-0 overflow-hidden text-ellipsis whitespace-nowrap font-semibold text-textPrimary">
+    <div className="flex flex-col justify-center overflow-hidden">
+      <h4 className="flex-shrink-0 truncate whitespace-nowrap font-semibold text-textPrimary">
         {application.name}
       </h4>
-      <p className="m-0 overflow-hidden text-ellipsis whitespace-nowrap text-sm text-textPrimary">
+      <div className="text-sm text-textPrimary line-clamp-3">
         {application.summary}
-      </p>
+      </div>
     </div>
   </Link>
 )

--- a/frontend/src/components/application/ApplicationSection.tsx
+++ b/frontend/src/components/application/ApplicationSection.tsx
@@ -35,7 +35,7 @@ const ApplicationSection: FunctionComponent<Props> = ({
           </ButtonLink>
         )}
       </header>
-      <div className="grid grid-cols-2 justify-around gap-4 lg:grid-cols-3 2xl:grid-cols-6">
+      <div className="grid grid-cols-1 justify-around gap-4 lg:grid-cols-3 2xl:grid-cols-3">
         {applications.map((app) => (
           <ApplicationCard key={app.id} application={app} />
         ))}

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -40,7 +40,7 @@ const ApplicationCollection: FunctionComponent<Props> = ({
           <h2>{title}</h2>
           <p>{t("number-of-results", { number: applications.length })}</p>
 
-          <div className="grid grid-cols-2 justify-around gap-4 lg:grid-cols-3 2xl:grid-cols-6">
+          <div className="grid grid-cols-1 justify-around gap-4 lg:grid-cols-3 2xl:grid-cols-3">
             {pagedApplications.map((app) => (
               <div key={app.id} className={"flex flex-col gap-2"}>
                 <ApplicationCard application={app} />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -24,5 +24,8 @@ module.exports = {
       },
     },
   },
-  plugins: [require("@tailwindcss/typography")],
+  plugins: [
+    require("@tailwindcss/typography"),
+    require("@tailwindcss/line-clamp"),
+  ],
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2970,6 +2970,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tailwindcss/line-clamp@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz#f353c5a8ab2c939c6267ac5b907f012e5ee130f9"
+  integrity sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==
+
 "@tailwindcss/typography@^0.5.8":
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.8.tgz#8fb31db5ab0590be6dfa062b1535ac86ad9d12bf"
@@ -3176,10 +3181,19 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/react@*", "@types/react@^17.0.43":
+"@types/react@*":
   version "17.0.43"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz"
   integrity sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.43":
+  version "17.0.52"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.52.tgz#10d8b907b5c563ac014a541f289ae8eaa9bf2e9b"
+  integrity sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
…f below

While this means less apps per row, it makes it way nicer to parse in my opinion. It allows for the summary to now actually be useful on the overview pages.

This was inspired by questioning what could be improved in the gnome designers channel.