### PR TITLE
New color handling

### DIFF
--- a/frontend/pages/about.tsx
+++ b/frontend/pages/about.tsx
@@ -12,7 +12,7 @@ const About = () => {
       <div className="flex flex-col">
         {/* <!-- header --> */}
         <header
-          className={`flex bg-flathubCyanBlueAzure dark:bg-flathubIndigo bg-none bg-contain bg-no-repeat px-[5%] md:px-[20%] lg:bg-[url('/img/about.svg')] 2xl:px-[30%]`}
+          className={`flex bg-flathubCyanBlueAzure bg-none bg-contain bg-no-repeat px-[5%] dark:bg-flathubIndigo md:px-[20%] lg:bg-[url('/img/about.svg')] 2xl:px-[30%]`}
         >
           <div className="text-gray-50">
             <h1>{t("about-pagename")}</h1>

--- a/frontend/pages/about.tsx
+++ b/frontend/pages/about.tsx
@@ -12,7 +12,7 @@ const About = () => {
       <div className="flex flex-col">
         {/* <!-- header --> */}
         <header
-          className={`flex bg-colorPrimary bg-none bg-contain bg-no-repeat px-[5%] md:px-[20%] lg:bg-[url('/img/about.svg')] 2xl:px-[30%]`}
+          className={`flex bg-flathubCyanBlueAzure dark:bg-flathubIndigo bg-none bg-contain bg-no-repeat px-[5%] md:px-[20%] lg:bg-[url('/img/about.svg')] 2xl:px-[30%]`}
         >
           <div className="text-gray-50">
             <h1>{t("about-pagename")}</h1>

--- a/frontend/pages/feeds.tsx
+++ b/frontend/pages/feeds.tsx
@@ -16,14 +16,18 @@ const Feeds = (): JSX.Element => {
         <h3>{t("new-apps")}</h3>
         <div className="flex flex-col pb-4">
           <p>{t("new-apps-description")}</p>
-          <ButtonLink href={FEED_NEW_URL} passHref>
+          <ButtonLink className="w-52" href={FEED_NEW_URL} passHref>
             {t("subscribe")}
           </ButtonLink>
         </div>
         <h3>{t("new-and-updated-apps")}</h3>
         <div className="flex flex-col pb-4">
           <p>{t("new-and-updated-apps-description")}</p>
-          <ButtonLink href={FEED_RECENTLY_UPDATED_URL} passHref>
+          <ButtonLink
+            className="w-52"
+            href={FEED_RECENTLY_UPDATED_URL}
+            passHref
+          >
             {t("subscribe")}
           </ButtonLink>
         </div>

--- a/frontend/pages/statistics.tsx
+++ b/frontend/pages/statistics.tsx
@@ -109,11 +109,10 @@ const Statistics = ({ stats }: { stats: Statistics }): JSX.Element => {
       count: countryValue,
     })
 
-    const translation = `${
-      translatedCountryName ??
+    const translation = `${translatedCountryName ??
       countries.getName(countryCode, "en") ??
       t("unknown")
-    }: ${downloadTranslation}`
+      }: ${downloadTranslation}`
 
     return translation
   }
@@ -170,20 +169,20 @@ const Statistics = ({ stats }: { stats: Statistics }): JSX.Element => {
         <h3>{t("downloads-per-country")}</h3>
         <div className={`flex justify-center ${styles.map}`}>
           <WorldMap
-            color="var(--color-primary)"
-            backgroundColor="var(--bg-color-secondary)"
-            borderColor="var(--text-primary)"
+            color="rgb(var(--color-primary))"
+            backgroundColor="rgb(var(--bg-color-secondary))"
+            borderColor="rgb(var(--text-primary))"
             size="responsive"
             data={country_data}
             tooltipTextFunction={getLocalizedText}
           />
         </div>
         <h3>{t("downloads-over-time")}</h3>
-        <div className="h-[500px] rounded-xl bg-bgColorSecondary p-4 shadow-md">
+        <div className="h-[500px] rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 shadow-md">
           <Line data={data} options={options} />
         </div>
         <h3>{t("category-distribution")}</h3>
-        <div className="h-[500px] rounded-xl bg-bgColorSecondary p-4 shadow-md">
+        <div className="h-[500px] rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 shadow-md">
           <Bar
             data={{
               labels: category_data.map((x) =>

--- a/frontend/pages/statistics.tsx
+++ b/frontend/pages/statistics.tsx
@@ -109,10 +109,11 @@ const Statistics = ({ stats }: { stats: Statistics }): JSX.Element => {
       count: countryValue,
     })
 
-    const translation = `${translatedCountryName ??
+    const translation = `${
+      translatedCountryName ??
       countries.getName(countryCode, "en") ??
       t("unknown")
-      }: ${downloadTranslation}`
+    }: ${downloadTranslation}`
 
     return translation
   }
@@ -178,11 +179,11 @@ const Statistics = ({ stats }: { stats: Statistics }): JSX.Element => {
           />
         </div>
         <h3>{t("downloads-over-time")}</h3>
-        <div className="h-[500px] rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 shadow-md">
+        <div className="h-[500px] rounded-xl bg-flathubWhite p-4 shadow-md dark:bg-flathubJet">
           <Line data={data} options={options} />
         </div>
         <h3>{t("category-distribution")}</h3>
-        <div className="h-[500px] rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 shadow-md">
+        <div className="h-[500px] rounded-xl bg-flathubWhite p-4 shadow-md dark:bg-flathubJet">
           <Bar
             data={{
               labels: category_data.map((x) =>

--- a/frontend/pages/userpage.tsx
+++ b/frontend/pages/userpage.tsx
@@ -26,7 +26,7 @@ export default function Userpage({
           <UserDetails logins={providers} />
           {!IS_PRODUCTION && <UserApps variant="owned" />}
           <UserApps variant="dev" />
-          <div className="rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 shadow-md">
+          <div className="rounded-xl bg-flathubWhite p-4 shadow-md dark:bg-flathubJet">
             <DeleteButton />
           </div>
         </LoginGuard>

--- a/frontend/pages/userpage.tsx
+++ b/frontend/pages/userpage.tsx
@@ -26,7 +26,7 @@ export default function Userpage({
           <UserDetails logins={providers} />
           {!IS_PRODUCTION && <UserApps variant="owned" />}
           <UserApps variant="dev" />
-          <div className="rounded-xl bg-bgColorSecondary p-4 shadow-md">
+          <div className="rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 shadow-md">
             <DeleteButton />
           </div>
         </LoginGuard>

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -26,8 +26,9 @@ const Button: FunctionComponent<Props> = forwardRef<HTMLButtonElement, Props>(
 
     return (
       <button
-        className={`${className ?? ""
-          } ${variantClass} no-wrap h-11 overflow-hidden text-ellipsis whitespace-nowrap rounded-lg px-5 py-2 text-center duration-500 enabled:hover:cursor-pointer enabled:active:bg-flathubGray98 active:dark:bg-flathubRaisinBlack enabled:active:text-flathubCyanBlueAzure dark:enabled:active:text-flathubIndigo disabled:cursor-default`}
+        className={`${
+          className ?? ""
+        } ${variantClass} no-wrap h-11 overflow-hidden text-ellipsis whitespace-nowrap rounded-lg px-5 py-2 text-center duration-500 enabled:hover:cursor-pointer enabled:active:bg-flathubGray98 enabled:active:text-flathubCyanBlueAzure disabled:cursor-default active:dark:bg-flathubRaisinBlack dark:enabled:active:text-flathubIndigo`}
         type={buttonProps.type}
         ref={ref}
         {...buttonProps}

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -17,18 +17,17 @@ const Button: FunctionComponent<Props> = forwardRef<HTMLButtonElement, Props>(
   ({ children, variant = "primary", className, ...buttonProps }, ref) => {
     const variantClass = {
       destructive:
-        "bg-bgColorSecondary text-colorDanger border border-colorDanger disabled:borden-none disabled:text-gray-100 enabled:hover:bg-colorDanger enabled:hover:text-gray-100",
+        "bg-flathubWhite dark:bg-flathubJet text-flathubElectricRed border border-flathubElectricRed disabled:borden-none disabled:text-gray-100 enabled:hover:bg-flathubElectricRed enabled:hover:text-gray-100",
       secondary:
-        "bg-bgButtonSecondary text-textPrimary disabled:border-none disabled:text-gray-100 disabled:bg-gray-500 enabled:hover:opacity-60",
+        "bg-flathubGray92 dark:bg-flathubOuterSpace text-flathubGunmetal  dark:text-flathubGray98 disabled:border-none disabled:text-gray-100 disabled:bg-gray-500 enabled:hover:opacity-60",
       primary:
-        "bg-colorPrimary text-gray-100 disabled:bg-gray-400 enabled:hover:opacity-75",
+        "bg-flathubCyanBlueAzure dark:bg-flathubIndigo text-gray-100 disabled:bg-gray-400 enabled:hover:opacity-75",
     }[variant]
 
     return (
       <button
-        className={`${
-          className ?? ""
-        } ${variantClass} no-wrap h-11 overflow-hidden text-ellipsis whitespace-nowrap rounded-lg px-5 py-2 text-center duration-500 enabled:hover:cursor-pointer enabled:active:bg-bgColorPrimary enabled:active:text-colorPrimary disabled:cursor-default`}
+        className={`${className ?? ""
+          } ${variantClass} no-wrap h-11 overflow-hidden text-ellipsis whitespace-nowrap rounded-lg px-5 py-2 text-center duration-500 enabled:hover:cursor-pointer enabled:active:bg-flathubGray98 active:dark:bg-flathubRaisinBlack enabled:active:text-flathubCyanBlueAzure dark:enabled:active:text-flathubIndigo disabled:cursor-default`}
         type={buttonProps.type}
         ref={ref}
         {...buttonProps}

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -40,16 +40,16 @@ const ButtonLink: FunctionComponent<Props> = forwardRef<
     ref,
   ) => {
     const hover = {
-      destructive: "hover:bg-colorDanger hover:text-gray-100",
+      destructive: "hover:bg-flathubElectricRed hover:text-gray-100",
       secondary: "hover:opacity-75",
       primary: "hover:opacity-75",
     }[variant]
 
     const variantClass = {
       destructive:
-        "bg-bgColorSecondary text-colorDanger border border-colorDanger",
-      secondary: "bg-bgButtonSecondary text-textPrimary",
-      primary: "bg-colorPrimary text-gray-100",
+        "bg-flathubWhite dark:bg-flathubJet text-flathubElectricRed border border-flathubElectricRed",
+      secondary: "bg-flathubGray92 dark:bg-flathubOuterSpace text-flathubGunmetal  dark:text-flathubGray98",
+      primary: "bg-flathubCyanBlueAzure dark:bg-flathubIndigo text-gray-100",
     }[variant]
 
     return (
@@ -62,9 +62,8 @@ const ButtonLink: FunctionComponent<Props> = forwardRef<
         target={target}
         rel={rel}
         tabIndex={-1}
-        className={`${
-          className ?? ""
-        }  ${hover} ${variantClass} no-wrap flex h-11 items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap rounded-lg px-5 py-2 text-center font-bold no-underline duration-500 hover:cursor-pointer active:bg-bgColorPrimary active:text-colorPrimary`}
+        className={`${className ?? ""
+          }  ${hover} ${variantClass} no-wrap flex h-11 items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap rounded-lg px-5 py-2 text-center font-bold no-underline duration-500 hover:cursor-pointer active:bg-flathubGray98/100 active:dark:bg-flathubRaisinBlack/100`}
         aria-label={ariaLabel}
         role="button"
       >

--- a/frontend/src/components/ButtonLink.tsx
+++ b/frontend/src/components/ButtonLink.tsx
@@ -48,7 +48,8 @@ const ButtonLink: FunctionComponent<Props> = forwardRef<
     const variantClass = {
       destructive:
         "bg-flathubWhite dark:bg-flathubJet text-flathubElectricRed border border-flathubElectricRed",
-      secondary: "bg-flathubGray92 dark:bg-flathubOuterSpace text-flathubGunmetal  dark:text-flathubGray98",
+      secondary:
+        "bg-flathubGray92 dark:bg-flathubOuterSpace text-flathubGunmetal  dark:text-flathubGray98",
       primary: "bg-flathubCyanBlueAzure dark:bg-flathubIndigo text-gray-100",
     }[variant]
 
@@ -62,8 +63,9 @@ const ButtonLink: FunctionComponent<Props> = forwardRef<
         target={target}
         rel={rel}
         tabIndex={-1}
-        className={`${className ?? ""
-          }  ${hover} ${variantClass} no-wrap flex h-11 items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap rounded-lg px-5 py-2 text-center font-bold no-underline duration-500 hover:cursor-pointer active:bg-flathubGray98/100 active:dark:bg-flathubRaisinBlack/100`}
+        className={`${
+          className ?? ""
+        }  ${hover} ${variantClass} no-wrap flex h-11 items-center justify-center overflow-hidden text-ellipsis whitespace-nowrap rounded-lg px-5 py-2 text-center font-bold no-underline duration-500 hover:cursor-pointer active:bg-flathubGray98/100 active:dark:bg-flathubRaisinBlack/100`}
         aria-label={ariaLabel}
         role="button"
       >

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -35,7 +35,7 @@ const ConfirmDialog: FunctionComponent<Props> = ({
         {t("entry-confirmation-prompt", { text: entry })}
       </Dialog.Description>
       <input
-        className="w-full rounded-xl border border-textSecondary p-3"
+        className="w-full rounded-xl border border-flathubNickel dark:border-flathubDarkGray p-3"
         value={text}
         onInput={(e) => setText((e.target as HTMLInputElement).value)}
       />
@@ -48,7 +48,7 @@ const ConfirmDialog: FunctionComponent<Props> = ({
         <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
         <div className="fixed inset-0 flex items-center justify-center p-4">
-          <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-bgColorPrimary p-14 shadow-md">
+          <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-flathubGray98 dark:bg-flathubRaisinBlack p-14 shadow-md">
             <Dialog.Title className="m-0">{prompt}</Dialog.Title>
 
             {entry ? toEnter : <></>}

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -35,7 +35,7 @@ const ConfirmDialog: FunctionComponent<Props> = ({
         {t("entry-confirmation-prompt", { text: entry })}
       </Dialog.Description>
       <input
-        className="w-full rounded-xl border border-flathubNickel dark:border-flathubDarkGray p-3"
+        className="w-full rounded-xl border border-flathubNickel p-3 dark:border-flathubDarkGray"
         value={text}
         onInput={(e) => setText((e.target as HTMLInputElement).value)}
       />
@@ -48,7 +48,7 @@ const ConfirmDialog: FunctionComponent<Props> = ({
         <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
         <div className="fixed inset-0 flex items-center justify-center p-4">
-          <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-flathubGray98 dark:bg-flathubRaisinBlack p-14 shadow-md">
+          <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-flathubGray98 p-14 shadow-md dark:bg-flathubRaisinBlack">
             <Dialog.Title className="m-0">{prompt}</Dialog.Title>
 
             {entry ? toEnter : <></>}

--- a/frontend/src/components/Disclosure.tsx
+++ b/frontend/src/components/Disclosure.tsx
@@ -11,11 +11,11 @@ export const FlathubDisclosure: FunctionComponent<{
     <Disclosure>
       {({ open }) => (
         <>
-          <Disclosure.Button className="flex w-full items-center gap-3 bg-bgColorSecondary px-4 py-3">
+          <Disclosure.Button className="flex w-full items-center gap-3 bg-flathubWhite dark:bg-flathubJet px-4 py-3">
             <HiChevronRight
               className={classNames(
                 open ? "rotate-90 " : "",
-                "h-6 w-6 transform text-textSecondary duration-150",
+                "h-6 w-6 transform text-flathubNickel dark:text-flathubDarkGray duration-150",
               )}
             />
             {buttonItems}

--- a/frontend/src/components/Disclosure.tsx
+++ b/frontend/src/components/Disclosure.tsx
@@ -11,11 +11,11 @@ export const FlathubDisclosure: FunctionComponent<{
     <Disclosure>
       {({ open }) => (
         <>
-          <Disclosure.Button className="flex w-full items-center gap-3 bg-flathubWhite dark:bg-flathubJet px-4 py-3">
+          <Disclosure.Button className="flex w-full items-center gap-3 bg-flathubWhite px-4 py-3 dark:bg-flathubJet">
             <HiChevronRight
               className={classNames(
                 open ? "rotate-90 " : "",
-                "h-6 w-6 transform text-flathubNickel dark:text-flathubDarkGray duration-150",
+                "h-6 w-6 transform text-flathubNickel duration-150 dark:text-flathubDarkGray",
               )}
             />
             {buttonItems}

--- a/frontend/src/components/InlineError.tsx
+++ b/frontend/src/components/InlineError.tsx
@@ -12,7 +12,7 @@ Typical UX is to show an error on form input blur event, then hide it on form in
 */
 const InlineError: FunctionComponent<Props> = ({ shown, error }) => {
   return shown ? (
-    <p role="alert" className="my-2 text-colorDanger">
+    <p role="alert" className="my-2 text-flathubElectricRed">
       {error}
     </p>
   ) : (

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -42,9 +42,8 @@ const Pagination: FunctionComponent<Props> = ({ currentPage, pages }) => {
                   })
                 }}
                 aria-current={isActive ? "page" : null}
-                className={`${
-                  isActive ? `bg-colorPrimary text-gray-50` : ""
-                }  h-12 w-12 rounded-full py-2 text-center no-underline duration-500 hover:cursor-pointer hover:opacity-50`}
+                className={`${isActive ? `bg-flathubCyanBlueAzure dark:bg-flathubIndigo text-gray-50` : ""
+                  }  h-12 w-12 rounded-full py-2 text-center no-underline duration-500 hover:cursor-pointer hover:opacity-50`}
               >
                 {curr}
               </a>

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -42,8 +42,11 @@ const Pagination: FunctionComponent<Props> = ({ currentPage, pages }) => {
                   })
                 }}
                 aria-current={isActive ? "page" : null}
-                className={`${isActive ? `bg-flathubCyanBlueAzure dark:bg-flathubIndigo text-gray-50` : ""
-                  }  h-12 w-12 rounded-full py-2 text-center no-underline duration-500 hover:cursor-pointer hover:opacity-50`}
+                className={`${
+                  isActive
+                    ? `bg-flathubCyanBlueAzure text-gray-50 dark:bg-flathubIndigo`
+                    : ""
+                }  h-12 w-12 rounded-full py-2 text-center no-underline duration-500 hover:cursor-pointer hover:opacity-50`}
               >
                 {curr}
               </a>

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -38,7 +38,7 @@ const Spinner: FunctionComponent<Props> = ({ size, text = undefined }) => {
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          className="fill-colorPrimary"
+          className="fill-flathubCyanBlueAzure dark:fill-flathubIndigo"
           d="M73,50c0-12.7-10.3-23-23-23S27,37.3,27,50 M30.9,50c0-10.5,8.5-19.1,19.1-19.1S69.1,39.5,69.1,50"
         >
           <animateTransform

--- a/frontend/src/components/Tile.tsx
+++ b/frontend/src/components/Tile.tsx
@@ -11,7 +11,7 @@ const Tile: FunctionComponent<Props> = forwardRef<HTMLAnchorElement, Props>(
   ({ children, className, onClick, href }, ref) => {
     return (
       <a
-        className={`flex items-center justify-center break-words rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 text-center text-flathubNickel dark:text-flathubDarkGray no-underline shadow-md duration-500 hover:bg-flathubGray98 hover:dark:bg-flathubRaisinBlack  ${className}`}
+        className={`flex items-center justify-center break-words rounded-xl bg-flathubWhite p-3 text-center text-flathubNickel no-underline shadow-md duration-500 hover:bg-flathubGray98 dark:bg-flathubJet dark:text-flathubDarkGray hover:dark:bg-flathubRaisinBlack  ${className}`}
         href={href}
         onClick={onClick}
         ref={ref}

--- a/frontend/src/components/Tile.tsx
+++ b/frontend/src/components/Tile.tsx
@@ -11,7 +11,7 @@ const Tile: FunctionComponent<Props> = forwardRef<HTMLAnchorElement, Props>(
   ({ children, className, onClick, href }, ref) => {
     return (
       <a
-        className={`flex items-center justify-center break-words rounded-xl bg-bgColorSecondary p-3 text-center text-textSecondary no-underline shadow-md duration-500 hover:bg-bgColorPrimary  ${className}`}
+        className={`flex items-center justify-center break-words rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 text-center text-flathubNickel dark:text-flathubDarkGray no-underline shadow-md duration-500 hover:bg-flathubGray98 hover:dark:bg-flathubRaisinBlack  ${className}`}
         href={href}
         onClick={onClick}
         ref={ref}

--- a/frontend/src/components/Toggle.tsx
+++ b/frontend/src/components/Toggle.tsx
@@ -18,7 +18,7 @@ const Toggle: FunctionComponent<Props> = ({ enabled, setEnabled }) => {
       checked={enabled}
       onChange={toggle}
       className={classNames(
-        enabled ? "bg-colorPrimary" : "bg-colorHighlight",
+        enabled ? "bg-flathubCyanBlueAzure dark:bg-flathubIndigo/75" : "bg-flathubCyanBlueAzure dark:bg-flathubIndigo",
         `relative inline-flex h-6 w-11 items-center rounded-full`,
       )}
     >

--- a/frontend/src/components/Toggle.tsx
+++ b/frontend/src/components/Toggle.tsx
@@ -18,7 +18,9 @@ const Toggle: FunctionComponent<Props> = ({ enabled, setEnabled }) => {
       checked={enabled}
       onChange={toggle}
       className={classNames(
-        enabled ? "bg-flathubCyanBlueAzure dark:bg-flathubIndigo/75" : "bg-flathubCyanBlueAzure dark:bg-flathubIndigo",
+        enabled
+          ? "bg-flathubCyanBlueAzure dark:bg-flathubIndigo/75"
+          : "bg-flathubCyanBlueAzure dark:bg-flathubIndigo",
         `relative inline-flex h-6 w-11 items-center rounded-full`,
       )}
     >

--- a/frontend/src/components/Toggle.tsx
+++ b/frontend/src/components/Toggle.tsx
@@ -19,8 +19,8 @@ const Toggle: FunctionComponent<Props> = ({ enabled, setEnabled }) => {
       onChange={toggle}
       className={classNames(
         enabled
-          ? "bg-flathubCyanBlueAzure dark:bg-flathubIndigo/75"
-          : "bg-flathubCyanBlueAzure dark:bg-flathubIndigo",
+          ? "bg-flathubCyanBlueAzure dark:bg-flathubIndigo"
+          : "bg-flathubNickel dark:bg-flathubOuterSpace",
         `relative inline-flex h-6 w-11 items-center rounded-full`,
       )}
     >

--- a/frontend/src/components/application/AppHeader.tsx
+++ b/frontend/src/components/application/AppHeader.tsx
@@ -37,7 +37,7 @@ export function AppHeader({
           <h2 className="my-0">{app.name}</h2>
         </div>
         {app.developer_name?.trim().length > 0 && (
-          <div className="text-center text-sm font-light text-textSecondary sm:text-start">
+          <div className="text-center text-sm font-light text-flathubNickel dark:text-flathubDarkGray sm:text-start">
             {t("by", {
               developer: app.developer_name,
             })}

--- a/frontend/src/components/application/AppStats.tsx
+++ b/frontend/src/components/application/AppStats.tsx
@@ -42,7 +42,7 @@ const AppStatistics: FunctionComponent<Props> = ({ stats }) => {
   const options = chartOptions(i18n.language, resolvedTheme as "light" | "dark")
 
   return (
-    <div className="h-[300px] rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 pb-16 shadow-md">
+    <div className="h-[300px] rounded-xl bg-flathubWhite p-4 pb-16 shadow-md dark:bg-flathubJet">
       <h3 className="mt-0">{t("installs-over-time")}</h3>
       <Line data={data} options={options} />
     </div>

--- a/frontend/src/components/application/AppStats.tsx
+++ b/frontend/src/components/application/AppStats.tsx
@@ -42,7 +42,7 @@ const AppStatistics: FunctionComponent<Props> = ({ stats }) => {
   const options = chartOptions(i18n.language, resolvedTheme as "light" | "dark")
 
   return (
-    <div className="h-[300px] rounded-xl bg-bgColorSecondary p-4 pb-16 shadow-md">
+    <div className="h-[300px] rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 pb-16 shadow-md">
       <h3 className="mt-0">{t("installs-over-time")}</h3>
       <Line data={data} options={options} />
     </div>

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
@@ -50,7 +50,7 @@ const TokenCreateDialog: FunctionComponent<Props> = ({
           <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
           <div className="fixed inset-0 flex items-center justify-center p-4">
-            <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-flathubGray98 dark:bg-flathubRaisinBlack p-14 shadow-md">
+            <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-flathubGray98 p-14 shadow-md dark:bg-flathubRaisinBlack">
               <Dialog.Title className="m-0">{t("create-tokens")}</Dialog.Title>
               <textarea
                 placeholder={t("token-creation-placeholder")}

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenCreateDialog.tsx
@@ -50,7 +50,7 @@ const TokenCreateDialog: FunctionComponent<Props> = ({
           <div className="fixed inset-0 bg-black/30" aria-hidden="true" />
 
           <div className="fixed inset-0 flex items-center justify-center p-4">
-            <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-bgColorPrimary p-14 shadow-md">
+            <Dialog.Panel className="inline-flex flex-col justify-center space-y-6 rounded-xl bg-flathubGray98 dark:bg-flathubRaisinBlack p-14 shadow-md">
               <Dialog.Title className="m-0">{t("create-tokens")}</Dialog.Title>
               <textarea
                 placeholder={t("token-creation-placeholder")}

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
@@ -53,7 +53,7 @@ const TokenList: FunctionComponent<Props> = ({ app }) => {
     content = <p>{t(error)}</p>
   } else {
     content = (
-      <div className="flex flex-col gap-2 rounded-2xl bg-bgColorSecondary p-2">
+      <div className="flex flex-col gap-2 rounded-2xl bg-flathubWhite dark:bg-flathubJet p-2">
         {tokens?.tokens.map((token) => (
           <Disclosure key={token.id}>
             {({ open }) => (

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenList.tsx
@@ -53,7 +53,7 @@ const TokenList: FunctionComponent<Props> = ({ app }) => {
     content = <p>{t(error)}</p>
   } else {
     content = (
-      <div className="flex flex-col gap-2 rounded-2xl bg-flathubWhite dark:bg-flathubJet p-2">
+      <div className="flex flex-col gap-2 rounded-2xl bg-flathubWhite p-2 dark:bg-flathubJet">
         {tokens?.tokens.map((token) => (
           <Disclosure key={token.id}>
             {({ open }) => (

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenListItem.tsx
@@ -19,7 +19,7 @@ const TokenListItem: FunctionComponent<Props> = ({ open, token, appId }) => {
 
   return (
     <>
-      <Disclosure.Button className="flex justify-between rounded-lg border p-2 hover:bg-colorHighlight focus:outline-none focus-visible:ring focus-visible:ring-opacity-75">
+      <Disclosure.Button className="flex justify-between rounded-lg border p-2 hover:opacity-80 focus:outline-none focus-visible:ring focus-visible:ring-opacity-75">
         <div className="grid w-full grid-cols-3 justify-items-start">
           <span>{token.id}</span>
           <span>{token.name}</span>

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
@@ -60,13 +60,13 @@ const TokenRedeemDialog: FunctionComponent<Props> = ({ app }) => {
   }
 
   return (
-    <div className="inline-flex gap-2 rounded-xl bg-flathubWhite dark:bg-flathubJet p-4">
+    <div className="inline-flex gap-2 rounded-xl bg-flathubWhite p-4 dark:bg-flathubJet">
       <input
         type="text"
         placeholder={t("token-redeem-placeholder")}
         value={text}
         onChange={textUpdate}
-        className="w-80 rounded-xl bg-flathubGray98 dark:bg-flathubRaisinBlack p-2"
+        className="w-80 rounded-xl bg-flathubGray98 p-2 dark:bg-flathubRaisinBlack"
       />
       <Button onClick={onSubmit}>{t("redeem-token")}</Button>
     </div>

--- a/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
+++ b/frontend/src/components/application/AppVendingControls/OwnershipTokens/TokenRedeemDialog.tsx
@@ -60,13 +60,13 @@ const TokenRedeemDialog: FunctionComponent<Props> = ({ app }) => {
   }
 
   return (
-    <div className="inline-flex gap-2 rounded-xl bg-bgColorSecondary p-4">
+    <div className="inline-flex gap-2 rounded-xl bg-flathubWhite dark:bg-flathubJet p-4">
       <input
         type="text"
         placeholder={t("token-redeem-placeholder")}
         value={text}
         onChange={textUpdate}
-        className="w-80 rounded-xl bg-bgColorPrimary p-2"
+        className="w-80 rounded-xl bg-flathubGray98 dark:bg-flathubRaisinBlack p-2"
       />
       <Button onClick={onSubmit}>{t("redeem-token")}</Button>
     </div>

--- a/frontend/src/components/application/AppVendingControls/PurchaseControls.tsx
+++ b/frontend/src/components/application/AppVendingControls/PurchaseControls.tsx
@@ -130,7 +130,7 @@ const PurchaseControls: FunctionComponent<Props> = ({ app, vendingConfig }) => {
 
   return (
     <form
-      className="my-5 mx-0 flex flex-col gap-5 rounded-xl bg-flathubWhite dark:bg-flathubJet p-5"
+      className="my-5 mx-0 flex flex-col gap-5 rounded-xl bg-flathubWhite p-5 dark:bg-flathubJet"
       onSubmit={handleSubmit}
     >
       {!isDonationOnly && (

--- a/frontend/src/components/application/AppVendingControls/PurchaseControls.tsx
+++ b/frontend/src/components/application/AppVendingControls/PurchaseControls.tsx
@@ -130,7 +130,7 @@ const PurchaseControls: FunctionComponent<Props> = ({ app, vendingConfig }) => {
 
   return (
     <form
-      className="my-5 mx-0 flex flex-col gap-5 rounded-xl bg-bgColorSecondary p-5"
+      className="my-5 mx-0 flex flex-col gap-5 rounded-xl bg-flathubWhite dark:bg-flathubJet p-5"
       onSubmit={handleSubmit}
     >
       {!isDonationOnly && (

--- a/frontend/src/components/application/AppVendingControls/SetupControls.tsx
+++ b/frontend/src/components/application/AppVendingControls/SetupControls.tsx
@@ -152,7 +152,7 @@ const SetupControls: FunctionComponent<Props> = ({ app, vendingConfig }) => {
   } else {
     content = (
       <form
-        className="flex flex-col gap-6 rounded-xl bg-bgColorSecondary p-4"
+        className="flex flex-col gap-6 rounded-xl bg-flathubWhite dark:bg-flathubJet p-4"
         onSubmit={handleSubmit}
       >
         <div className="flex gap-3 border-b border-slate-400/20 pb-3">

--- a/frontend/src/components/application/AppVendingControls/SetupControls.tsx
+++ b/frontend/src/components/application/AppVendingControls/SetupControls.tsx
@@ -152,7 +152,7 @@ const SetupControls: FunctionComponent<Props> = ({ app, vendingConfig }) => {
   } else {
     content = (
       <form
-        className="flex flex-col gap-6 rounded-xl bg-flathubWhite dark:bg-flathubJet p-4"
+        className="flex flex-col gap-6 rounded-xl bg-flathubWhite p-4 dark:bg-flathubJet"
         onSubmit={handleSubmit}
       >
         <div className="flex gap-3 border-b border-slate-400/20 pb-3">

--- a/frontend/src/components/application/AppVerificationControls/SetupControls.tsx
+++ b/frontend/src/components/application/AppVerificationControls/SetupControls.tsx
@@ -111,7 +111,7 @@ const AppVerificationSetup: FunctionComponent<Props> = ({ app }) => {
         <p>{t("error")}</p>
         {error && <p>{error}</p>}
         {verificationMethods?.detail && (
-          <span className="text-xs text-textSecondary">
+          <span className="text-xs text-flathubNickel dark:text-flathubDarkGray">
             {t("error-code", { code: verificationMethods.detail })}
           </span>
         )}

--- a/frontend/src/components/application/AppVerificationControls/WebsiteVerification.tsx
+++ b/frontend/src/components/application/AppVerificationControls/WebsiteVerification.tsx
@@ -91,7 +91,7 @@ const WebsiteVerification: FunctionComponent<Props> = ({
         <>
           <p>{t("error")}</p>
           {confirmResult.detail && (
-            <span className="text-xs text-textSecondary">
+            <span className="text-xs text-flathubNickel dark:text-flathubDarkGray">
               {t("error-code", { code: confirmResult.detail })}
             </span>
           )}
@@ -105,7 +105,7 @@ const WebsiteVerification: FunctionComponent<Props> = ({
           <Trans i18nKey={"website-validation-instruction"}>
             Create a page at <a href={webpage}>{{ webpage }}</a> containing the
             following token:
-            <div className="p-3 font-semibold text-textSecondary">
+            <div className="p-3 font-semibold text-flathubNickel dark:text-flathubDarkGray">
               {{ token }}
             </div>
             If the page already exists, add the token to it.

--- a/frontend/src/components/application/ApplicationCard.tsx
+++ b/frontend/src/components/application/ApplicationCard.tsx
@@ -12,16 +12,16 @@ const ApplicationCard: FunctionComponent<Props> = ({ application }) => (
   <Link
     href={`/apps/${application.id}`}
     passHref
-    className="flex min-w-0 items-center gap-4 rounded-xl bg-bgColorSecondary p-4 shadow-md duration-500 hover:cursor-pointer hover:no-underline hover:shadow-xl hover:brightness-95 active:bg-bgColorPrimary"
+    className="flex min-w-0 items-center gap-4 rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 shadow-md duration-500 hover:cursor-pointer hover:no-underline hover:shadow-xl hover:brightness-95 active:bg-flathubGray98 active:dark:bg-flathubRaisinBlack"
   >
     <div className="relative h-[64px] w-[64px] flex-shrink-0 flex-wrap items-center justify-center drop-shadow-md md:h-[128px] md:w-[128px]">
       <LogoImage iconUrl={application.icon} appName={application.name} />
     </div>
     <div className="flex flex-col justify-center overflow-hidden">
-      <h4 className="flex-shrink-0 truncate whitespace-nowrap font-semibold text-textPrimary">
+      <h4 className="flex-shrink-0 truncate whitespace-nowrap font-semibold text-flathubGunmetal dark:text-flathubGray98">
         {application.name}
       </h4>
-      <div className="text-sm text-textPrimary line-clamp-3">
+      <div className="text-sm text-flathubGunmetal dark:text-flathubGray98 line-clamp-3">
         {application.summary}
       </div>
     </div>

--- a/frontend/src/components/application/ApplicationCard.tsx
+++ b/frontend/src/components/application/ApplicationCard.tsx
@@ -12,7 +12,7 @@ const ApplicationCard: FunctionComponent<Props> = ({ application }) => (
   <Link
     href={`/apps/${application.id}`}
     passHref
-    className="flex min-w-0 items-center gap-4 rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 shadow-md duration-500 hover:cursor-pointer hover:no-underline hover:shadow-xl hover:brightness-95 active:bg-flathubGray98 active:dark:bg-flathubRaisinBlack"
+    className="flex min-w-0 items-center gap-4 rounded-xl bg-flathubWhite p-4 shadow-md duration-500 hover:cursor-pointer hover:no-underline hover:shadow-xl hover:brightness-95 active:bg-flathubGray98 dark:bg-flathubJet active:dark:bg-flathubRaisinBlack"
   >
     <div className="relative h-[64px] w-[64px] flex-shrink-0 flex-wrap items-center justify-center drop-shadow-md md:h-[128px] md:w-[128px]">
       <LogoImage iconUrl={application.icon} appName={application.name} />
@@ -21,7 +21,7 @@ const ApplicationCard: FunctionComponent<Props> = ({ application }) => (
       <h4 className="flex-shrink-0 truncate whitespace-nowrap font-semibold text-flathubGunmetal dark:text-flathubGray98">
         {application.name}
       </h4>
-      <div className="text-sm text-flathubGunmetal dark:text-flathubGray98 line-clamp-3">
+      <div className="text-sm text-flathubGunmetal line-clamp-3 dark:text-flathubGray98">
         {application.summary}
       </div>
     </div>

--- a/frontend/src/components/application/CmdInstructions.tsx
+++ b/frontend/src/components/application/CmdInstructions.tsx
@@ -25,7 +25,7 @@ const CmdInstructions = ({ appId }: { appId: string }) => {
   }
 
   return (
-    <div className="rounded-xl bg-flathubWhite dark:bg-flathubJet px-4 pb-4 shadow-md">
+    <div className="rounded-xl bg-flathubWhite px-4 pb-4 shadow-md dark:bg-flathubJet">
       <h3>{t("manual-install")}</h3>
       <p>
         <Trans i18nKey={"common:manual-install-instructions"}>

--- a/frontend/src/components/application/CmdInstructions.tsx
+++ b/frontend/src/components/application/CmdInstructions.tsx
@@ -25,7 +25,7 @@ const CmdInstructions = ({ appId }: { appId: string }) => {
   }
 
   return (
-    <div className="rounded-xl bg-bgColorSecondary px-4 pb-4 shadow-md">
+    <div className="rounded-xl bg-flathubWhite dark:bg-flathubJet px-4 pb-4 shadow-md">
       <h3>{t("manual-install")}</h3>
       <p>
         <Trans i18nKey={"common:manual-install-instructions"}>

--- a/frontend/src/components/application/CodeCopy.tsx
+++ b/frontend/src/components/application/CodeCopy.tsx
@@ -30,9 +30,8 @@ const CodeCopy: FunctionComponent<Props> = ({
 
   return (
     <div
-      className={`relative mx-0 mt-0 mb-3 block overflow-auto rounded-xl bg-bgColorSecondary p-2 pr-10 text-sm text-textSecondary shadow-md ${
-        styles.pre
-      } ${className ?? ""} ${nested ? "bg-bgColorPrimary" : ""}`}
+      className={`relative mx-0 mt-0 mb-3 block overflow-auto rounded-xl bg-flathubWhite dark:bg-flathubJet p-2 pr-10 text-sm text-flathubNickel dark:text-flathubDarkGray shadow-md ${styles.pre
+        } ${className ?? ""} ${nested ? "bg-flathubGray98 dark:bg-flathubRaisinBlack" : ""}`}
     >
       {text}
       <CopyToClipboard
@@ -43,7 +42,7 @@ const CodeCopy: FunctionComponent<Props> = ({
         }}
       >
         <button
-          className="absolute right-1 top-1 cursor-pointer border-none bg-transparent text-2xl text-textSecondary hover:text-textPrimary"
+          className="absolute right-1 top-1 cursor-pointer border-none bg-transparent text-2xl text-flathubNickel dark:text-flathubDarkGray hover:text-flathubGunmetal hover:dark:text-flathubGray98"
           title={t("copy-text")}
         >
           {!copied && <HiSquare2Stack></HiSquare2Stack>}

--- a/frontend/src/components/application/CodeCopy.tsx
+++ b/frontend/src/components/application/CodeCopy.tsx
@@ -30,8 +30,11 @@ const CodeCopy: FunctionComponent<Props> = ({
 
   return (
     <div
-      className={`relative mx-0 mt-0 mb-3 block overflow-auto rounded-xl bg-flathubWhite dark:bg-flathubJet p-2 pr-10 text-sm text-flathubNickel dark:text-flathubDarkGray shadow-md ${styles.pre
-        } ${className ?? ""} ${nested ? "bg-flathubGray98 dark:bg-flathubRaisinBlack" : ""}`}
+      className={`relative mx-0 mt-0 mb-3 block overflow-auto rounded-xl bg-flathubWhite p-2 pr-10 text-sm text-flathubNickel shadow-md dark:bg-flathubJet dark:text-flathubDarkGray ${
+        styles.pre
+      } ${className ?? ""} ${
+        nested ? "bg-flathubGray98 dark:bg-flathubRaisinBlack" : ""
+      }`}
     >
       {text}
       <CopyToClipboard
@@ -42,7 +45,7 @@ const CodeCopy: FunctionComponent<Props> = ({
         }}
       >
         <button
-          className="absolute right-1 top-1 cursor-pointer border-none bg-transparent text-2xl text-flathubNickel dark:text-flathubDarkGray hover:text-flathubGunmetal hover:dark:text-flathubGray98"
+          className="absolute right-1 top-1 cursor-pointer border-none bg-transparent text-2xl text-flathubNickel hover:text-flathubGunmetal dark:text-flathubDarkGray hover:dark:text-flathubGray98"
           title={t("copy-text")}
         >
           {!copied && <HiSquare2Stack></HiSquare2Stack>}

--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -172,7 +172,7 @@ const Details: FunctionComponent<Props> = ({
           <div className="max-w-11/12 relative mx-auto my-0 2xl:max-w-[1400px]">
             {app.screenshots && app.screenshots.length > 0 && (
               <Button
-                className="!hover:text-gray-100 absolute right-3 bottom-3 z-10 h-12 w-12 rounded-xl bg-flathubGray92 dark:bg-flathubOuterSpace px-3 py-3 text-2xl !text-flathubNickel dark:text-flathubDarkGray hover:cursor-pointer hover:bg-opacity-50"
+                className="!hover:text-gray-100 absolute right-3 bottom-3 z-10 h-12 w-12 rounded-xl bg-flathubGray92 px-3 py-3 text-2xl !text-flathubNickel hover:cursor-pointer hover:bg-opacity-50 dark:bg-flathubOuterSpace dark:text-flathubDarkGray"
                 onClick={() => setShowLightbox(true)}
                 aria-label={t("zoom")}
               >
@@ -256,7 +256,7 @@ const Details: FunctionComponent<Props> = ({
           </div>
           {scrollHeight > collapsedHeight && (
             <button {...getToggleProps()}>
-              <span className="m-0 w-full rounded-xl bg-flathubWhite dark:bg-flathubJet/80 py-2 px-6 font-semibold shadow-md transition hover:cursor-pointer hover:bg-flathubWhite dark:bg-flathubJet">
+              <span className="m-0 w-full rounded-xl bg-flathubWhite py-2 px-6 font-semibold shadow-md transition hover:cursor-pointer hover:bg-flathubWhite dark:bg-flathubJet/80 dark:bg-flathubJet">
                 {isExpanded ? t(`show-less`) : t(`show-more`)}
               </span>
             </button>

--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -256,7 +256,7 @@ const Details: FunctionComponent<Props> = ({
           </div>
           {scrollHeight > collapsedHeight && (
             <button {...getToggleProps()}>
-              <span className="m-0 w-full rounded-xl bg-flathubWhite py-2 px-6 font-semibold shadow-md transition hover:cursor-pointer hover:bg-flathubWhite dark:bg-flathubJet/80 dark:bg-flathubJet">
+              <span className="m-0 w-full rounded-xl bg-flathubWhite py-2 px-6 font-semibold shadow-md transition hover:cursor-pointer hover:bg-flathubWhite dark:bg-flathubJet/80 hover:dark:bg-flathubJet">
                 {isExpanded ? t(`show-less`) : t(`show-more`)}
               </span>
             </button>

--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -161,7 +161,7 @@ const Details: FunctionComponent<Props> = ({
           vendingSetup={vendingSetup}
           verificationStatus={verificationStatus}
         />
-        <div className="col-start-1 col-end-4 bg-bgColorSecondary">
+        <div className="col-start-1 col-end-4 bg-flathubWhite dark:bg-flathubJet">
           <Lightbox
             open={showLightbox}
             close={() => setShowLightbox(false)}
@@ -172,7 +172,7 @@ const Details: FunctionComponent<Props> = ({
           <div className="max-w-11/12 relative mx-auto my-0 2xl:max-w-[1400px]">
             {app.screenshots && app.screenshots.length > 0 && (
               <Button
-                className="!hover:text-gray-100 absolute right-3 bottom-3 z-10 h-12 w-12 rounded-xl bg-bgButtonSecondary px-3 py-3 text-2xl !text-textSecondary hover:cursor-pointer hover:bg-opacity-50"
+                className="!hover:text-gray-100 absolute right-3 bottom-3 z-10 h-12 w-12 rounded-xl bg-flathubGray92 dark:bg-flathubOuterSpace px-3 py-3 text-2xl !text-flathubNickel dark:text-flathubDarkGray hover:cursor-pointer hover:bg-opacity-50"
                 onClick={() => setShowLightbox(true)}
                 aria-label={t("zoom")}
               >
@@ -256,7 +256,7 @@ const Details: FunctionComponent<Props> = ({
           </div>
           {scrollHeight > collapsedHeight && (
             <button {...getToggleProps()}>
-              <span className="m-0 w-full rounded-xl bg-bgColorSecondary py-2 px-6 font-semibold shadow-md hover:cursor-pointer hover:bg-colorHighlight">
+              <span className="m-0 w-full rounded-xl bg-flathubWhite dark:bg-flathubJet/80 py-2 px-6 font-semibold shadow-md transition hover:cursor-pointer hover:bg-flathubWhite dark:bg-flathubJet">
                 {isExpanded ? t(`show-less`) : t(`show-more`)}
               </span>
             </button>

--- a/frontend/src/components/application/ListBox.tsx
+++ b/frontend/src/components/application/ListBox.tsx
@@ -9,8 +9,8 @@ interface Props {
     icon: string | JSX.Element
     header: string
     content:
-    | { type: "url"; text: string; trackAsEvent: string }
-    | { type: "text"; text: string }
+      | { type: "url"; text: string; trackAsEvent: string }
+      | { type: "text"; text: string }
   }[]
 }
 
@@ -34,10 +34,11 @@ const ListBox: FunctionComponent<Props> = ({ appId, items }) => {
             }
             return (
               <div
-                className={`grid w-full grid-cols-[36px_calc(100%_-_36px_-_36px)_36px] bg-flathubWhite dark:bg-flathubJet p-4 shadow-md first:rounded-tl-xl first:rounded-tr-xl last:rounded-bl-xl last:rounded-br-xl ${item.content.type === "text"
-                  ? "grid-cols-[36px_calc(100%_-_36px)]"
-                  : ""
-                  }`}
+                className={`grid w-full grid-cols-[36px_calc(100%_-_36px_-_36px)_36px] bg-flathubWhite p-4 shadow-md first:rounded-tl-xl first:rounded-tr-xl last:rounded-bl-xl last:rounded-br-xl dark:bg-flathubJet ${
+                  item.content.type === "text"
+                    ? "grid-cols-[36px_calc(100%_-_36px)]"
+                    : ""
+                }`}
                 key={index}
               >
                 <div className="self-center text-2xl text-flathubNickel dark:text-flathubDarkGray">

--- a/frontend/src/components/application/ListBox.tsx
+++ b/frontend/src/components/application/ListBox.tsx
@@ -9,8 +9,8 @@ interface Props {
     icon: string | JSX.Element
     header: string
     content:
-      | { type: "url"; text: string; trackAsEvent: string }
-      | { type: "text"; text: string }
+    | { type: "url"; text: string; trackAsEvent: string }
+    | { type: "text"; text: string }
   }[]
 }
 
@@ -34,20 +34,19 @@ const ListBox: FunctionComponent<Props> = ({ appId, items }) => {
             }
             return (
               <div
-                className={`grid w-full grid-cols-[36px_calc(100%_-_36px_-_36px)_36px] bg-bgColorSecondary p-4 shadow-md first:rounded-tl-xl first:rounded-tr-xl last:rounded-bl-xl last:rounded-br-xl ${
-                  item.content.type === "text"
-                    ? "grid-cols-[36px_calc(100%_-_36px)]"
-                    : ""
-                }`}
+                className={`grid w-full grid-cols-[36px_calc(100%_-_36px_-_36px)_36px] bg-flathubWhite dark:bg-flathubJet p-4 shadow-md first:rounded-tl-xl first:rounded-tr-xl last:rounded-bl-xl last:rounded-br-xl ${item.content.type === "text"
+                  ? "grid-cols-[36px_calc(100%_-_36px)]"
+                  : ""
+                  }`}
                 key={index}
               >
-                <div className="self-center text-2xl text-textSecondary">
+                <div className="self-center text-2xl text-flathubNickel dark:text-flathubDarkGray">
                   {item.icon}
                 </div>
                 <div className="text-base">
                   {item.header}
                   {item.content.type === "text" && (
-                    <span className="block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-textSecondary">
+                    <span className="block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-flathubNickel dark:text-flathubDarkGray">
                       {item.content.text}
                     </span>
                   )}
@@ -57,7 +56,7 @@ const ListBox: FunctionComponent<Props> = ({ appId, items }) => {
                       target="_blank"
                       rel="noreferrer"
                       onClick={linkClicked}
-                      className="block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-textSecondary"
+                      className="block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-flathubNickel dark:text-flathubDarkGray"
                     >
                       {item.content.text}
                     </a>

--- a/frontend/src/components/application/Releases.tsx
+++ b/frontend/src/components/application/Releases.tsx
@@ -56,7 +56,7 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
   return (
     <>
       {latestRelease && (
-        <div className="rounded-xl bg-flathubWhite dark:bg-flathubJet shadow-md">
+        <div className="rounded-xl bg-flathubWhite shadow-md dark:bg-flathubJet">
           <div>
             <div className="flex flex-col gap-2 px-4 pt-4">
               <header className="flex flex-col gap-2 sm:flex-row sm:justify-between">
@@ -84,10 +84,11 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
               </header>
               <div
                 {...getCollapseProps()}
-                className={`prose relative transition-all duration-700 dark:prose-invert ${!isExpanded && scrollHeight > collapsedHeight
-                  ? "from-transparent to-flathubWhite dark:to-flathubJet before:absolute before:left-0 before:top-0 before:h-full before:w-full before:bg-gradient-to-b before:content-['']"
-                  : ""
-                  }`}
+                className={`prose relative transition-all duration-700 dark:prose-invert ${
+                  !isExpanded && scrollHeight > collapsedHeight
+                    ? "from-transparent to-flathubWhite before:absolute before:left-0 before:top-0 before:h-full before:w-full before:bg-gradient-to-b before:content-[''] dark:to-flathubJet"
+                    : ""
+                }`}
                 ref={ref}
                 dangerouslySetInnerHTML={{
                   __html: releaseDescription,

--- a/frontend/src/components/application/Releases.tsx
+++ b/frontend/src/components/application/Releases.tsx
@@ -56,7 +56,7 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
   return (
     <>
       {latestRelease && (
-        <div className="rounded-xl bg-bgColorSecondary shadow-md">
+        <div className="rounded-xl bg-flathubWhite dark:bg-flathubJet shadow-md">
           <div>
             <div className="flex flex-col gap-2 px-4 pt-4">
               <header className="flex flex-col gap-2 sm:flex-row sm:justify-between">
@@ -84,11 +84,10 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
               </header>
               <div
                 {...getCollapseProps()}
-                className={`prose relative transition-[height] transition-all duration-700 dark:prose-invert ${
-                  !isExpanded && scrollHeight > collapsedHeight
-                    ? "from-transparent to-bgColorSecondary before:absolute before:left-0 before:top-0 before:h-full before:w-full before:bg-gradient-to-b before:content-['']"
-                    : ""
-                }`}
+                className={`prose relative transition-all duration-700 dark:prose-invert ${!isExpanded && scrollHeight > collapsedHeight
+                  ? "from-transparent to-flathubWhite dark:to-flathubJet before:absolute before:left-0 before:top-0 before:h-full before:w-full before:bg-gradient-to-b before:content-['']"
+                  : ""
+                  }`}
                 ref={ref}
                 dangerouslySetInnerHTML={{
                   __html: releaseDescription,
@@ -97,7 +96,7 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
             </div>
             {scrollHeight > collapsedHeight && (
               <button
-                className="w-full rounded-tl-none rounded-tr-none rounded-bl-xl rounded-br-xl border-t py-3 px-0 font-semibold transition hover:cursor-pointer hover:bg-colorHighlight dark:border-zinc-600"
+                className="w-full rounded-tl-none rounded-tr-none rounded-bl-xl rounded-br-xl border-t py-3 px-0 font-semibold transition hover:cursor-pointer hover:bg-white/5 dark:border-zinc-600"
                 {...getToggleProps()}
               >
                 {isExpanded ? (

--- a/frontend/src/components/application/Verification.tsx
+++ b/frontend/src/components/application/Verification.tsx
@@ -116,11 +116,11 @@ const Verification: FunctionComponent<Props> = ({
 
   if (verificationStatus?.verified == true) {
     return (
-      <div className="flex items-center justify-center gap-1 text-sm text-textSecondary sm:justify-start">
+      <div className="flex items-center justify-center gap-1 text-sm text-flathubNickel dark:text-flathubDarkGray sm:justify-start">
         {verifiedLink}
         <button ref={reference} {...getReferenceProps}>
           <HiCheckBadge
-            className="h-6 w-6 text-colorLink"
+            className="h-6 w-6 text-flathubCyanBlueAzure"
             aria-label={t("app-is-verified")}
           />
         </button>
@@ -133,7 +133,7 @@ const Verification: FunctionComponent<Props> = ({
               top: y ?? 0,
               left: x ?? 0,
             }}
-            className="rounded-xl bg-bgColorSecondary p-4"
+            className="rounded-xl bg-flathubWhite dark:bg-flathubJet p-4"
             {...getFloatingProps()}
           >
             {
@@ -180,7 +180,7 @@ const Verification: FunctionComponent<Props> = ({
 
             <div
               ref={arrowRef}
-              className="absolute h-4 w-4 rotate-45 bg-bgColorSecondary"
+              className="absolute h-4 w-4 rotate-45 bg-flathubWhite dark:bg-flathubJet"
               style={{
                 top: arrowY != null ? `${arrowY}px` : "",
                 left: arrowX != null ? `${arrowX}px` : "",

--- a/frontend/src/components/application/Verification.tsx
+++ b/frontend/src/components/application/Verification.tsx
@@ -133,7 +133,7 @@ const Verification: FunctionComponent<Props> = ({
               top: y ?? 0,
               left: x ?? 0,
             }}
-            className="rounded-xl bg-flathubWhite dark:bg-flathubJet p-4"
+            className="rounded-xl bg-flathubWhite p-4 dark:bg-flathubJet"
             {...getFloatingProps()}
           >
             {

--- a/frontend/src/components/currency/CurrencyInput.tsx
+++ b/frontend/src/components/currency/CurrencyInput.tsx
@@ -81,7 +81,7 @@ const CurrencyInput: FunctionComponent<Props> = forwardRef<
         onBlur={handleBlur}
         ref={ref}
         className={
-          "rounded-xl border-none bg-flathubGray98 dark:bg-flathubRaisinBlack p-2 pl-7 text-flathubGunmetal  dark:text-flathubGray98 outline-none"
+          "rounded-xl border-none bg-flathubGray98 p-2 pl-7 text-flathubGunmetal outline-none  dark:bg-flathubRaisinBlack dark:text-flathubGray98"
         }
         {...inputProps}
       />

--- a/frontend/src/components/currency/CurrencyInput.tsx
+++ b/frontend/src/components/currency/CurrencyInput.tsx
@@ -81,7 +81,7 @@ const CurrencyInput: FunctionComponent<Props> = forwardRef<
         onBlur={handleBlur}
         ref={ref}
         className={
-          "rounded-xl border-none bg-bgColorPrimary p-2 pl-7 text-textPrimary outline-none"
+          "rounded-xl border-none bg-flathubGray98 dark:bg-flathubRaisinBlack p-2 pl-7 text-flathubGunmetal  dark:text-flathubGray98 outline-none"
         }
         {...inputProps}
       />

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
   const { t } = useTranslation()
 
   return (
-    <footer className="mt-16 bg-flathubCyanBlueAzure dark:bg-flathubIndigo p-12">
+    <footer className="mt-16 bg-flathubCyanBlueAzure p-12 dark:bg-flathubIndigo">
       <div className="mx-auto grid max-w-[900px] grid-cols-1 justify-items-center gap-0 sm:grid-cols-2 md:grid-cols-4">
         <div className="m-3 min-w-[200px] text-gray-100 ">
           <div className="flex justify-center text-2xl font-bold sm:block sm:text-base">

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -5,7 +5,7 @@ const Footer = () => {
   const { t } = useTranslation()
 
   return (
-    <footer className="mt-16 bg-colorPrimary p-12">
+    <footer className="mt-16 bg-flathubCyanBlueAzure dark:bg-flathubIndigo p-12">
       <div className="mx-auto grid max-w-[900px] grid-cols-1 justify-items-center gap-0 sm:grid-cols-2 md:grid-cols-4">
         <div className="m-3 min-w-[200px] text-gray-100 ">
           <div className="flex justify-center text-2xl font-bold sm:block sm:text-base">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -107,7 +107,7 @@ const Header = () => {
         className={({ open }) =>
           classNames(
             open ? "fixed inset-0 overflow-y-auto" : "",
-            "fixed z-40 w-full bg-colorPrimary shadow-sm lg:overflow-y-visible",
+            "fixed z-40 w-full bg-flathubCyanBlueAzure dark:bg-flathubIndigo shadow-sm lg:overflow-y-visible",
           )
         }
       >
@@ -123,7 +123,7 @@ const Header = () => {
                     />
                     <Link href="/" passHref>
                       <div
-                        className="h-10 w-10 cursor-pointer rounded-lg bg-[url('/img/flathub-logo.png')] bg-contain bg-center bg-no-repeat px-4 py-2 hover:bg-colorHighlight lg:w-[150px] lg:bg-[url('/img/logo/flathub-logo-toolbar.svg')] lg:bg-auto lg:bg-origin-content"
+                        className="h-10 w-10 cursor-pointer rounded-lg bg-[url('/img/flathub-logo.png')] bg-contain bg-center bg-no-repeat px-4 py-2 hover:bg-white/5 lg:w-[150px] lg:bg-[url('/img/logo/flathub-logo-toolbar.svg')] lg:bg-auto lg:bg-origin-content"
                         title={t("go-home")}
                       />
                     </Link>
@@ -159,7 +159,7 @@ const Header = () => {
                             value={query}
                             className={
                               (i18n.dir() === "rtl" ? "md:pr-10 " : "") +
-                              "block w-full rounded-full bg-bgColorPrimary py-2 pl-10 pr-3 text-sm placeholder-gray-500 focus:border-textPrimary focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-textPrimary dark:text-textPrimary dark:focus:text-white sm:text-sm"
+                              "block w-full rounded-full bg-flathubGray98 dark:bg-flathubRaisinBlack py-2 pl-10 pr-3 text-sm placeholder-gray-500 focus:border-flathubGunmetal dark:focus:border-flathubGray98 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-flathubGunmetal dark:focus:ring-flathubGray98 dark:text-flathubGray98 dark:focus:text-white sm:text-sm"
                             }
                             placeholder={t("search-apps")}
                             type="search"
@@ -179,7 +179,7 @@ const Header = () => {
                 </div>
                 <div className="flex items-center md:absolute md:inset-y-0 md:right-0 lg:hidden">
                   {/* Mobile menu button */}
-                  <Popover.Button className="-mx-2 inline-flex items-center justify-center rounded-md p-2 text-white hover:bg-colorHighlight focus:outline-none">
+                  <Popover.Button className="-mx-2 inline-flex items-center justify-center rounded-md p-2 text-white hover:bg-white/5 focus:outline-none">
                     <span className="sr-only">{t("open-menu")}</span>
                     {open ? (
                       <HiXMark className="block h-6 w-6" aria-hidden="true" />
@@ -197,7 +197,7 @@ const Header = () => {
                           key={item.name}
                           target="_blank"
                           rel="noreferrer"
-                          className="ml-4 inline-flex items-center rounded-md border border-transparent bg-colorPrimary px-4 py-2 text-sm font-medium text-white no-underline hover:bg-colorHighlight"
+                          className="ml-4 inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white no-underline hover:bg-white/5"
                         >
                           {t(item.name)}
                         </a>
@@ -208,7 +208,7 @@ const Header = () => {
                           passHref
                           href={item.href}
                           key={item.name}
-                          className="ml-4 inline-flex items-center rounded-md border border-transparent bg-colorPrimary px-4 py-2 text-sm font-medium text-white no-underline hover:bg-colorHighlight"
+                          className="ml-4 inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white no-underline hover:bg-white/5"
                         >
                           {t(item.name)}
                         </Link>
@@ -220,7 +220,7 @@ const Header = () => {
                       passHref
                       href="/login"
                       key="login"
-                      className="ml-4 inline-flex items-center rounded-md border border-transparent bg-colorPrimary px-4 py-2 text-sm font-medium text-white no-underline hover:bg-colorHighlight"
+                      className="ml-4 inline-flex items-center rounded-md border border-transparent px-4 py-2 text-sm font-medium text-white no-underline hover:bg-white/5"
                     >
                       {t("login")}
                     </Link>
@@ -228,7 +228,7 @@ const Header = () => {
 
                   {/* Profile dropdown */}
                   {user.info && (
-                    <Menu as="div" className="colorPrimary-0 relative ml-5">
+                    <Menu as="div" className="relative ml-5">
                       <div>
                         <Menu.Button className="flex rounded-full bg-white no-underline">
                           <span className="sr-only">{t("open-user-menu")}</span>
@@ -308,10 +308,8 @@ const Header = () => {
                             rel="noreferrer"
                             aria-current={item.current ? "page" : undefined}
                             className={classNames(
-                              item.current
-                                ? "bg-colorHighlight"
-                                : "hover:bg-colorHighlight",
-                              "block rounded-md py-2 px-3 text-base font-medium text-white no-underline dark:text-textPrimary",
+                              item.current ? "bg-white/5" : "hover:bg-white/5",
+                              "block rounded-md py-2 px-3 text-base font-medium text-white no-underline dark:text-flathubGray98",
                             )}
                           >
                             {t(item.name)}
@@ -331,10 +329,8 @@ const Header = () => {
                             }}
                             aria-current={item.current ? "page" : undefined}
                             className={classNames(
-                              item.current
-                                ? "bg-colorHighlight"
-                                : "hover:bg-colorHighlight",
-                              "block rounded-md py-2 px-3 text-base font-medium text-white no-underline dark:text-textPrimary",
+                              item.current ? "bg-white/5" : "hover:bg-white/5",
+                              "block rounded-md py-2 px-3 text-base font-medium text-white no-underline dark:text-flathubGray98",
                             )}
                           >
                             {t(item.name)}
@@ -348,7 +344,7 @@ const Header = () => {
                         href="/login"
                         key="login"
                         className={classNames(
-                          "block rounded-md py-2 px-3 text-base font-medium text-white no-underline hover:bg-colorHighlight dark:text-textPrimary",
+                          "block rounded-md py-2 px-3 text-base font-medium text-white no-underline hover:bg-white/5 dark:text-flathubGray98",
                         )}
                         onClick={() => {
                           close()
@@ -377,7 +373,7 @@ const Header = () => {
                           />
                         </div>
                         <div className="ml-3">
-                          <div className="text-base font-medium text-white dark:text-textPrimary ">
+                          <div className="text-base font-medium text-white dark:text-flathubGray98 ">
                             {user.info.displayname}
                           </div>
                         </div>
@@ -388,7 +384,7 @@ const Header = () => {
                             key={item.name}
                             href={item.href}
                             passHref
-                            className="block rounded-md py-2 px-3 text-base font-medium text-white no-underline hover:bg-colorHighlight dark:text-textPrimary"
+                            className="block rounded-md py-2 px-3 text-base font-medium text-white no-underline hover:bg-white/5 dark:text-flathubGray98"
                             onClick={() => {
                               close()
                             }}
@@ -402,7 +398,7 @@ const Header = () => {
                             onLogout()
                             close()
                           }}
-                          className="block w-full rounded-md py-2 px-3 text-left text-base font-medium text-white hover:bg-colorHighlight dark:text-textPrimary"
+                          className="block w-full rounded-md py-2 px-3 text-left text-base font-medium text-white hover:bg-white/5 dark:text-flathubGray98"
                         >
                           {t("log-out")}
                         </button>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -107,7 +107,7 @@ const Header = () => {
         className={({ open }) =>
           classNames(
             open ? "fixed inset-0 overflow-y-auto" : "",
-            "fixed z-40 w-full bg-flathubCyanBlueAzure dark:bg-flathubIndigo shadow-sm lg:overflow-y-visible",
+            "fixed z-40 w-full bg-flathubCyanBlueAzure shadow-sm dark:bg-flathubIndigo lg:overflow-y-visible",
           )
         }
       >
@@ -159,7 +159,7 @@ const Header = () => {
                             value={query}
                             className={
                               (i18n.dir() === "rtl" ? "md:pr-10 " : "") +
-                              "block w-full rounded-full bg-flathubGray98 dark:bg-flathubRaisinBlack py-2 pl-10 pr-3 text-sm placeholder-gray-500 focus:border-flathubGunmetal dark:focus:border-flathubGray98 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-flathubGunmetal dark:focus:ring-flathubGray98 dark:text-flathubGray98 dark:focus:text-white sm:text-sm"
+                              "block w-full rounded-full bg-flathubGray98 py-2 pl-10 pr-3 text-sm placeholder-gray-500 focus:border-flathubGunmetal focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-flathubGunmetal dark:bg-flathubRaisinBlack dark:text-flathubGray98 dark:focus:border-flathubGray98 dark:focus:text-white dark:focus:ring-flathubGray98 sm:text-sm"
                             }
                             placeholder={t("search-apps")}
                             type="search"

--- a/frontend/src/components/layout/Main.tsx
+++ b/frontend/src/components/layout/Main.tsx
@@ -13,7 +13,7 @@ const Main: FunctionComponent = ({ children }) => {
   }, [trackPageView])
 
   return (
-    <div className="flex min-h-screen flex-col bg-bgColorPrimary">
+    <div className="flex min-h-screen flex-col bg-flathubGray98 dark:bg-flathubRaisinBlack">
       <Header />
 
       <main className="pt-16">{children}</main>

--- a/frontend/src/components/login/ProviderLink.tsx
+++ b/frontend/src/components/login/ProviderLink.tsx
@@ -67,8 +67,8 @@ const ProviderLink: FunctionComponent<Props> = ({
     <button
       className={classNames(
         "flex w-full flex-row items-center justify-center gap-3 rounded-xl ",
-        "p-5 shadow-md hover:cursor-pointer hover:opacity-60 active:bg-bgColorPrimary",
-        inACard ? "bg-bgColorPrimary" : "bg-bgColorSecondary",
+        "p-5 shadow-md hover:cursor-pointer hover:opacity-60 active:bg-flathubGray98 active:dark:bg-flathubRaisinBlack",
+        inACard ? "bg-flathubGray98 dark:bg-flathubRaisinBlack" : "bg-flathubWhite dark:bg-flathubJet",
       )}
       onClick={onClick}
     >

--- a/frontend/src/components/login/ProviderLink.tsx
+++ b/frontend/src/components/login/ProviderLink.tsx
@@ -68,7 +68,9 @@ const ProviderLink: FunctionComponent<Props> = ({
       className={classNames(
         "flex w-full flex-row items-center justify-center gap-3 rounded-xl ",
         "p-5 shadow-md hover:cursor-pointer hover:opacity-60 active:bg-flathubGray98 active:dark:bg-flathubRaisinBlack",
-        inACard ? "bg-flathubGray98 dark:bg-flathubRaisinBlack" : "bg-flathubWhite dark:bg-flathubJet",
+        inACard
+          ? "bg-flathubGray98 dark:bg-flathubRaisinBlack"
+          : "bg-flathubWhite dark:bg-flathubJet",
       )}
       onClick={onClick}
     >

--- a/frontend/src/components/payment/DonationInput.tsx
+++ b/frontend/src/components/payment/DonationInput.tsx
@@ -60,7 +60,7 @@ const DonationInput: FunctionComponent<Props> = ({ org }) => {
 
   return (
     <form
-      className="my-5 mx-0 flex flex-col gap-5 rounded-xl bg-bgColorSecondary p-5"
+      className="my-5 mx-0 flex flex-col gap-5 rounded-xl bg-flathubWhite dark:bg-flathubJet p-5"
       onSubmit={handleSubmit}
     >
       <h4 className="m-0">{t("select-donation-amount")}</h4>

--- a/frontend/src/components/payment/DonationInput.tsx
+++ b/frontend/src/components/payment/DonationInput.tsx
@@ -60,7 +60,7 @@ const DonationInput: FunctionComponent<Props> = ({ org }) => {
 
   return (
     <form
-      className="my-5 mx-0 flex flex-col gap-5 rounded-xl bg-flathubWhite dark:bg-flathubJet p-5"
+      className="my-5 mx-0 flex flex-col gap-5 rounded-xl bg-flathubWhite p-5 dark:bg-flathubJet"
       onSubmit={handleSubmit}
     >
       <h4 className="m-0">{t("select-donation-amount")}</h4>

--- a/frontend/src/components/payment/cards/CardInfo.tsx
+++ b/frontend/src/components/payment/cards/CardInfo.tsx
@@ -22,7 +22,7 @@ const CardInfo: FunctionComponent<Props> = ({ card, onClick, className }) => {
   const { resolvedTheme } = useTheme()
 
   const classes = [
-    "grid grid-cols-3 grid-rows-3 shadow-md w-[250px] min-w-[200px] p-4 rounded-xl bg-bgColorSecondary max-w-[300px]",
+    "grid grid-cols-3 grid-rows-3 shadow-md w-[250px] min-w-[200px] p-4 rounded-xl bg-flathubWhite dark:bg-flathubJet max-w-[300px]",
   ]
   if (onClick) {
     classes.push("hover:cursor-pointer")
@@ -67,7 +67,7 @@ const CardInfo: FunctionComponent<Props> = ({ card, onClick, className }) => {
       <span className="col-span-3 row-start-3 flex">
         <div className="flex flex-col font-bold ">
           <div className="text-gray-400 dark:text-gray-500">{t("expiry")}</div>
-          <div className="text-textPrimary">
+          <div className="text-flathubGunmetal  dark:text-flathubGray98">
             {card.exp_month} / {card.exp_year}
           </div>
         </div>

--- a/frontend/src/components/payment/checkout/CardSelect.tsx
+++ b/frontend/src/components/payment/checkout/CardSelect.tsx
@@ -83,7 +83,7 @@ const CardSelect: FunctionComponent<Props> = ({
           onClick={() => setUseCard(card)}
           className={
             useCard && card.id === useCard.id
-              ? "border border-colorPrimary"
+              ? "border border-flathubCyanBlueAzure dark:border-flathubIndigo"
               : ""
           }
         />

--- a/frontend/src/components/payment/checkout/PaymentForm.tsx
+++ b/frontend/src/components/payment/checkout/PaymentForm.tsx
@@ -35,7 +35,7 @@ const PaymentForm: FunctionComponent<Props> = ({
 
   return (
     <form
-      className="flex flex-col gap-4 p-5 text-textPrimary"
+      className="flex flex-col gap-4 p-5 text-flathubGunmetal  dark:text-flathubGray98"
       onSubmit={handleSubmit}
     >
       <PaymentElement />

--- a/frontend/src/components/payment/transactions/TransactionHistory.tsx
+++ b/frontend/src/components/payment/transactions/TransactionHistory.tsx
@@ -63,14 +63,14 @@ const TransactionPanel = ({
 
   if (transactionDetailed == null && !error) {
     return (
-      <div className="flex flex-col gap-3 rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 shadow-md">
+      <div className="flex flex-col gap-3 rounded-xl bg-flathubWhite p-3 shadow-md dark:bg-flathubJet">
         <Spinner size="m" />
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 shadow-md">
+    <div className="flex flex-col gap-3 rounded-xl bg-flathubWhite p-3 shadow-md dark:bg-flathubJet">
       {error && (
         <>
           <h1>{t("whoops")}</h1>

--- a/frontend/src/components/payment/transactions/TransactionHistory.tsx
+++ b/frontend/src/components/payment/transactions/TransactionHistory.tsx
@@ -63,14 +63,14 @@ const TransactionPanel = ({
 
   if (transactionDetailed == null && !error) {
     return (
-      <div className="flex flex-col gap-3 rounded-xl bg-bgColorSecondary p-3 shadow-md">
+      <div className="flex flex-col gap-3 rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 shadow-md">
         <Spinner size="m" />
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl bg-bgColorSecondary p-3 shadow-md">
+    <div className="flex flex-col gap-3 rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 shadow-md">
       {error && (
         <>
           <h1>{t("whoops")}</h1>

--- a/frontend/src/components/payment/transactions/TransactionPayout.tsx
+++ b/frontend/src/components/payment/transactions/TransactionPayout.tsx
@@ -11,7 +11,7 @@ const TransactionPayout: FunctionComponent<Props> = ({ payout }) => {
   const { t, i18n } = useTranslation()
 
   return (
-    <div className="flex flex-wrap gap-3 rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 shadow-md">
+    <div className="flex flex-wrap gap-3 rounded-xl bg-flathubWhite p-3 shadow-md dark:bg-flathubJet">
       <span>
         {formatCurrency(payout.amount / 100, i18n.language, payout.currency)}
       </span>

--- a/frontend/src/components/payment/transactions/TransactionPayout.tsx
+++ b/frontend/src/components/payment/transactions/TransactionPayout.tsx
@@ -11,7 +11,7 @@ const TransactionPayout: FunctionComponent<Props> = ({ payout }) => {
   const { t, i18n } = useTranslation()
 
   return (
-    <div className="flex flex-wrap gap-3 rounded-xl bg-bgColorSecondary p-3 shadow-md">
+    <div className="flex flex-wrap gap-3 rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 shadow-md">
       <span>
         {formatCurrency(payout.amount / 100, i18n.language, payout.currency)}
       </span>

--- a/frontend/src/components/payment/transactions/TransactionSummary.tsx
+++ b/frontend/src/components/payment/transactions/TransactionSummary.tsx
@@ -22,7 +22,7 @@ const TransactionSummary: FunctionComponent<Props> = ({ transaction }) => {
   const prettyValue = formatCurrency(value / 100, i18n.language)
 
   return (
-    <div className="rounded-xl bg-bgColorSecondary p-3 shadow-md">
+    <div className="rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 shadow-md">
       <p className="m-0">
         {t("transaction-summary-id", { id })}
         <br />

--- a/frontend/src/components/payment/transactions/TransactionSummary.tsx
+++ b/frontend/src/components/payment/transactions/TransactionSummary.tsx
@@ -22,7 +22,7 @@ const TransactionSummary: FunctionComponent<Props> = ({ transaction }) => {
   const prettyValue = formatCurrency(value / 100, i18n.language)
 
   return (
-    <div className="rounded-xl bg-flathubWhite dark:bg-flathubJet p-3 shadow-md">
+    <div className="rounded-xl bg-flathubWhite p-3 shadow-md dark:bg-flathubJet">
       <p className="m-0">
         {t("transaction-summary-id", { id })}
         <br />

--- a/frontend/src/components/user/Details.tsx
+++ b/frontend/src/components/user/Details.tsx
@@ -29,7 +29,7 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
       return (
         <div
           key={provider.method}
-          className="flex w-full items-center gap-3 rounded-xl bg-bgColorPrimary py-2 px-6 text-textPrimary shadow-md md:w-auto"
+          className="flex w-full items-center gap-3 rounded-xl bg-flathubGray98 dark:bg-flathubRaisinBlack py-2 px-6 text-flathubGunmetal  dark:text-flathubGray98 shadow-md md:w-auto"
         >
           <Image
             src={authData.avatar}
@@ -66,7 +66,7 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
   )
 
   return (
-    <div className="grid rounded-xl bg-bgColorSecondary p-4 text-textPrimary shadow-md">
+    <div className="grid rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 text-flathubGunmetal  dark:text-flathubGray98 shadow-md">
       <h2 className="col-start-1 row-start-1 mt-0 mb-3">
         {user.info.displayname}
       </h2>

--- a/frontend/src/components/user/Details.tsx
+++ b/frontend/src/components/user/Details.tsx
@@ -29,7 +29,7 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
       return (
         <div
           key={provider.method}
-          className="flex w-full items-center gap-3 rounded-xl bg-flathubGray98 dark:bg-flathubRaisinBlack py-2 px-6 text-flathubGunmetal  dark:text-flathubGray98 shadow-md md:w-auto"
+          className="flex w-full items-center gap-3 rounded-xl bg-flathubGray98 py-2 px-6 text-flathubGunmetal shadow-md  dark:bg-flathubRaisinBlack dark:text-flathubGray98 md:w-auto"
         >
           <Image
             src={authData.avatar}
@@ -66,7 +66,7 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
   )
 
   return (
-    <div className="grid rounded-xl bg-flathubWhite dark:bg-flathubJet p-4 text-flathubGunmetal  dark:text-flathubGray98 shadow-md">
+    <div className="grid rounded-xl bg-flathubWhite p-4 text-flathubGunmetal shadow-md  dark:bg-flathubJet dark:text-flathubGray98">
       <h2 className="col-start-1 row-start-1 mt-0 mb-3">
         {user.info.displayname}
       </h2>

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -74,25 +74,34 @@
     @apply p-0;
     @apply m-0;
     @apply overflow-x-hidden;
-    @apply text-textPrimary;
+    @apply text-flathubRaisinBlack;
     @apply min-h-screen;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    html,
+    body {
+      @apply text-flathubGray98;
+    }
   }
 }
 
 :root {
-  --white: hsl(0, 0%, 98%);
-  --bg-color-primary: var(--white);
-  --bg-color-secondary: hsl(0, 0%, 100%);
+  // colors used via tailwind
+  --flathub-cyan-blue-azure: 74 134 207;
+  --flathub-indigo: 27 60 101;
+  --flathub-electric-red: 226 0 0;
 
-  --bg-button-secondary: hsl(0, 0%, 92.2%);
-
-  --text-primary: hsl(195, 8%, 19.6%);
-  --text-secondary: hsl(0, 0%, 44.7%);
-
-  --color-primary: hsl(212.9, 58.1%, 55.1%);
-  --color-danger: hsl(0, 100%, 44.3%);
-
-  --color-highlight: rgba(0, 0, 0, 0.1);
+  // grays
+  --flathub-white: 255 255 255;
+  --flathub-gray-98: 250 250 250;
+  --flathub-gray-92: 235 235 235;
+  --flathub-dark-gray: 170 170 170;
+  --flathub-nickel: 114 114 114;
+  --flathub-outer-space: 73 73 73;
+  --flathub-jet: 53 53 53;
+  --flathub-gunmetal: 46 52 54;
+  --flathub-raisin-black: 36 36 36;
 
   --base-border-radius: 12px;
   --button-border-radius: 8px;
@@ -100,35 +109,30 @@
 
   --toastify-font-family: inherit;
 
-  --color-link: var(--color-primary);
+
+  // for worldmap and below css
+  --text-primary: var(--flathub-gunmetal);
+  --bg-color-secondary: var(--flathub-white);
+  --color-primary: var(--flathub-cyan-blue-azure);
 }
 
 [data-theme="dark"] {
   // Override react-tostify variable here for easy theme adherence
-  --toastify-color-light: var(--toastify-color-dark);
-  --toastify-text-color-light: var(--text-primary);
+  --toastify-color-light: var(--toastify-color-dark); // todo: check if this ever worked
+  --toastify-text-color-light: var(--flathub-gray-98);
 
-  --bg-color-primary: hsl(0, 0%, 14.1%);
-  --bg-color-secondary: hsl(0, 0%, 20.8%);
 
-  --bg-button-secondary: hsl(0, 0%, 28.6%);
-
-  --text-primary: var(--white);
-  --text-secondary: rgba(255, 255, 255, 0.6);
-
-  --color-primary: hsl(212.9, 58.1%, calc(55.1% - 30%));
-
-  --color-highlight: rgba(255, 255, 255, 0.1);
-
-  --color-link: hsl(212.9, 58.1%, 55.1%);
+  --text-primary: var(--flathub-gray-98);
+  --bg-color-secondary: var(--flathub-jet);
+  --color-primary: var(--flathub-indigo);
 }
+
 a {
-  color: var(--color-link);
+  color: rgb(var(--flathub-cyan-blue-azure));
 }
 
 .carousel {
   outline: none;
-  background: var(--bg-color-secondary);
   width: 100%;
 
   .control-arrow {
@@ -143,9 +147,13 @@ a {
     padding: 8px 7px !important;
     border-radius: var(--button-border-radius) !important;
 
-    background-color: var(--bg-button-secondary) !important;
-    color: var(--link-color) !important;
+    background-color: rgb(var(--flathub-gray-92)) !important;
+    color: rgb(var(--flathub-gunmetal)) !important;
 
+    @media (prefers-color-scheme: dark) {
+      background-color: rgb(var(--flathub-outer-space)) !important;
+      color: rgb(var(--flathub-gray-98)) !important;
+    }
     &:hover {
       opacity: 0.5 !important;
     }
@@ -170,14 +178,13 @@ a {
   .slide {
     margin-bottom: 60px;
     margin-top: 20px;
-    background-color: var(--bg-color-secondary);
   }
 
   .control-dots {
     margin-bottom: 20px;
 
     .dot {
-      background-color: var(--text-primary);
+      background-color: rgb(var(--text-primary));
       opacity: 0.4;
       box-shadow: none;
       transform: scale(1);

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -74,7 +74,7 @@
     @apply p-0;
     @apply m-0;
     @apply overflow-x-hidden;
-    @apply text-flathubRaisinBlack;
+    @apply text-flathubGunmetal;
     @apply min-h-screen;
   }
 

--- a/frontend/styles/main.scss
+++ b/frontend/styles/main.scss
@@ -109,7 +109,6 @@
 
   --toastify-font-family: inherit;
 
-
   // for worldmap and below css
   --text-primary: var(--flathub-gunmetal);
   --bg-color-secondary: var(--flathub-white);
@@ -118,9 +117,10 @@
 
 [data-theme="dark"] {
   // Override react-tostify variable here for easy theme adherence
-  --toastify-color-light: var(--toastify-color-dark); // todo: check if this ever worked
+  --toastify-color-light: var(
+    --toastify-color-dark
+  ); // todo: check if this ever worked
   --toastify-text-color-light: var(--flathub-gray-98);
-
 
   --text-primary: var(--flathub-gray-98);
   --bg-color-secondary: var(--flathub-jet);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,19 +1,24 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: ["class", '[data-theme="dark"]'],
   important: true,
   content: ["./pages/**/*.{js,ts,jsx,tsx}", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
     extend: {
       colors: {
-        bgColorPrimary: "var(--bg-color-primary)",
-        bgColorSecondary: "var(--bg-color-secondary)",
-        bgButtonSecondary: "var(--bg-button-secondary)",
-        textPrimary: "var(--text-primary)",
-        textSecondary: "var(--text-secondary)",
-        colorPrimary: "var(--color-primary)",
-        colorDanger: "var(--color-danger)",
-        colorHighlight: "var(--color-highlight)",
-        colorLink: "var(--color-link)",
+        flathubGray98: "rgb(var(--flathub-gray-98) / <alpha-value>)",
+        flathubRaisinBlack: "rgb(var(--flathub-raisin-black) / <alpha-value>)",
+        flathubWhite: "rgb(var(--flathub-white) / <alpha-value>)",
+        flathubJet: "rgb(var(--flathub-jet) / <alpha-value>)",
+        flathubGray92: "rgb(var(--flathub-gray-92) / <alpha-value>)",
+        flathubOuterSpace: "rgb(var(--flathub-outer-space) / <alpha-value>)",
+        flathubGunmetal: "rgb(var(--flathub-gunmetal) / <alpha-value>)",
+        flathubNickel: "rgb(var(--flathub-nickel) / <alpha-value>)",
+        flathubDarkGray: "rgb(var(--flathub-dark-gray) / <alpha-value>)",
+        flathubCyanBlueAzure:
+          "rgb(var(--flathub-cyan-blue-azure) / <alpha-value>)",
+        flathubIndigo: "rgb(var(--flathub-indigo) / <alpha-value>)",
+        flathubElectricRed: "rgb(var(--flathub-electric-red) / <alpha-value>)",
       },
       boxShadow: {
         md: "0 0 0 1px rgba(0, 0, 0, 0.03), 0 1px 3px 1px rgba(0, 0, 0, 0.07), 0 2px 6px 2px rgba(0, 0, 0, 0.03)",


### PR DESCRIPTION
We'll this was some work.

But after all, the only thing that seems to have slightly changed is one of the black tones in the light variant.

I've kept the linter formatting in it's own commit, as it might be helpful to be able to figure stuff out later, to have the previous commit.

I've reviewed this quiet a bit from a user POV, but I'll like to do a normal code review in the next days.

Basically what this means, is that we can use colors more freely and can use the transparencies of them via tailwind.
See https://tailwindcss.com/docs/customizing-colors#using-css-variables as a reference.