### PR TITLE
Add button/endpoint to refresh dev-flatpaks

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -56,6 +56,7 @@
   "loading-user-apps": "Loading user apps…",
   "your-apps": "Authored Apps",
   "owned-apps": "Owned Apps",
+  "refresh": "Refresh",
   "app-logo": "{{app-name}} Logo",
   "user-page": "User Page",
   "user-wallet": "User Wallet",

--- a/frontend/src/asyncs/app.ts
+++ b/frontend/src/asyncs/app.ts
@@ -5,6 +5,7 @@ import {
   APP_VERIFICATION_UNVERIFY,
   APP_VERIFICATION_VERIFY_BY_LOGIN_PROVIDER,
   CHECK_PURCHASES_URL,
+  REFRESH_DEV_FLATPAKS,
   TOKEN_GENERATION_URL,
 } from "../env"
 import { Appstream } from "../types/Appstream"
@@ -108,6 +109,20 @@ export async function confirmWebsiteVerification(
 export async function unverifyApp(appId: string): Promise<void> {
   try {
     await fetch(APP_VERIFICATION_UNVERIFY(appId), {
+      method: "POST",
+      credentials: "include",
+    })
+  } catch {
+    throw "network-error-try-again"
+  }
+}
+
+/**
+ * Refreshes the user's dev flatpaks list.
+ */
+export async function refreshDevFlatpaks(): Promise<void> {
+  try {
+    await fetch(REFRESH_DEV_FLATPAKS, {
       method: "POST",
       credentials: "include",
     })

--- a/frontend/src/asyncs/app.ts
+++ b/frontend/src/asyncs/app.ts
@@ -120,12 +120,14 @@ export async function unverifyApp(appId: string): Promise<void> {
 /**
  * Refreshes the user's dev flatpaks list.
  */
-export async function refreshDevFlatpaks(): Promise<void> {
+export async function refreshDevFlatpaks(): Promise<string[]> {
   try {
-    await fetch(REFRESH_DEV_FLATPAKS, {
+    const res = await fetch(REFRESH_DEV_FLATPAKS, {
       method: "POST",
       credentials: "include",
     })
+
+    return (await res.json())["dev-flatpaks"]
   } catch {
     throw "network-error-try-again"
   }

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -33,17 +33,6 @@ const ApplicationCollection: FunctionComponent<Props> = ({
 }) => {
   const { t } = useTranslation()
   const router = useRouter()
-  if (!page) {
-    page = parseInt((router.query.page ?? "1") as string)
-  }
-  if (!totalPages) {
-    totalPages = Math.ceil(applications.length / perPage)
-  }
-  const pages = Array.from({ length: totalPages }, (_, i) => i + 1)
-
-  const pagedApplications = totalHits
-    ? applications
-    : applications.slice((page - 1) * perPage, page * perPage)
 
   const refresh = onRefresh ? (
     <Button onClick={onRefresh}>{t("refresh")}</Button>
@@ -68,6 +57,18 @@ const ApplicationCollection: FunctionComponent<Props> = ({
       </div>
     )
   }
+
+  if (!page) {
+    page = parseInt((router.query.page ?? "1") as string)
+  }
+  if (!totalPages) {
+    totalPages = Math.ceil(applications.length / perPage)
+  }
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1)
+
+  const pagedApplications = totalHits
+    ? applications
+    : applications.slice((page - 1) * perPage, page * perPage)
 
   return (
     <div className="flex">

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -1,14 +1,14 @@
-import { FunctionComponent } from "react"
 import { useRouter } from "next/router"
+import { FunctionComponent } from "react"
 
 import { Appstream, AppstreamListItem } from "../../types/Appstream"
 
-import ApplicationCard from "./ApplicationCard"
-import Pagination from "../Pagination"
 import { useTranslation } from "next-i18next"
-import ButtonLink from "../ButtonLink"
 import { UserState } from "src/types/Login"
 import Button from "../Button"
+import ButtonLink from "../ButtonLink"
+import Pagination from "../Pagination"
+import ApplicationCard from "./ApplicationCard"
 
 interface Props {
   applications: Appstream[] | AppstreamListItem[]

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -8,6 +8,7 @@ import Pagination from "../Pagination"
 import { useTranslation } from "next-i18next"
 import ButtonLink from "../ButtonLink"
 import { UserState } from "src/types/Login"
+import Button from "../Button"
 
 interface Props {
   applications: Appstream[] | AppstreamListItem[]
@@ -17,6 +18,7 @@ interface Props {
   page?: number
   totalPages?: number
   totalHits?: number
+  onRefresh?: () => void
 }
 
 const ApplicationCollection: FunctionComponent<Props> = ({
@@ -27,6 +29,7 @@ const ApplicationCollection: FunctionComponent<Props> = ({
   page,
   totalPages,
   totalHits,
+  onRefresh,
 }) => {
   const { t } = useTranslation()
   const router = useRouter()
@@ -42,11 +45,36 @@ const ApplicationCollection: FunctionComponent<Props> = ({
     ? applications
     : applications.slice((page - 1) * perPage, page * perPage)
 
+  const refresh = onRefresh ? (
+    <Button onClick={onRefresh}>{t("refresh")}</Button>
+  ) : null
+
+  const header = (
+    <span className="flex items-center justify-between">
+      <h2>{title}</h2>
+      {refresh}
+    </span>
+  )
+
+  if (applications.length === 0) {
+    return (
+      <div className="flex">
+        <section className="w-full">
+          <div className="w-full">
+            {header}
+            <p>{t("no-applications")}</p>
+          </div>
+        </section>
+      </div>
+    )
+  }
+
   return (
     <div className="flex">
       <section className="min-h-[750px] w-full">
         <div className="w-full">
-          <h2>{title}</h2>
+          {header}
+
           <p>
             {t("number-of-results", {
               number: totalHits ?? applications.length,

--- a/frontend/src/components/user/UserApps.tsx
+++ b/frontend/src/components/user/UserApps.tsx
@@ -1,6 +1,5 @@
 import { useTranslation } from "next-i18next"
 import { FunctionComponent, useCallback, useEffect } from "react"
-import { getUserData } from "src/asyncs/login"
 import { getAppsInfo, refreshDevFlatpaks } from "../../asyncs/app"
 import { useUserContext, useUserDispatch } from "../../context/user-info"
 import { useAsync } from "../../hooks/useAsync"
@@ -23,17 +22,20 @@ const UserApps: FunctionComponent<Props> = ({ variant }) => {
   const { execute, status, value: apps } = useAsync(getApps, false)
 
   const doRefreshDev = useCallback(async () => {
-    await refreshDevFlatpaks()
-    await getUserData(userDispatch)
+    const devFlatpaks = await refreshDevFlatpaks()
+    userDispatch({ type: "update-dev-flatpaks", devFlatpaks })
   }, [userDispatch])
-  const { execute: executeRefreshDev } = useAsync(doRefreshDev, false)
+  const { execute: executeRefreshDev, status: refreshStatus } = useAsync(
+    doRefreshDev,
+    false,
+  )
 
   // User app list not available until login context resolves
   useEffect(() => {
     if (user.info) execute()
   }, [user.info, execute])
 
-  if (["idle", "pending"].includes(status)) {
+  if (["idle", "pending"].includes(status) || refreshStatus === "pending") {
     return <Spinner size="m" text={t("loading-user-apps")} />
   }
 

--- a/frontend/src/context/reducer.ts
+++ b/frontend/src/context/reducer.ts
@@ -25,6 +25,14 @@ export function contextReducer(
       return {
         loading: false,
       }
+    case "update-dev-flatpaks":
+      return {
+        ...state,
+        info: {
+          ...state.info,
+          "dev-flatpaks": action.devFlatpaks,
+        },
+      }
     default:
       return state
   }

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -126,4 +126,6 @@ export const APP_VERIFICATION_CONFIRM_WEBSITE = (id: string): string =>
 export const APP_VERIFICATION_UNVERIFY = (id: string): string =>
   `${BASE_URI}/verification/${id}/unverify`
 
+export const REFRESH_DEV_FLATPAKS = `${BASE_URI}/auth/refresh-dev-flatpaks`
+
 export const REQUEST_ORG_ACCESS_LINK_GITHUB: string = `${BASE_URI}/verification/request-organization-access/github`

--- a/frontend/src/types/Login.ts
+++ b/frontend/src/types/Login.ts
@@ -29,8 +29,9 @@ export interface UserState {
 
 // For calls to user state reducer's dispatch method
 export interface UserStateAction {
-  type: string
+  type: "loading" | "interrupt" | "login" | "logout" | "update-dev-flatpaks"
   info?: UserInfo
+  devFlatpaks?: string[]
 }
 
 // GET /auth/deleteuser


### PR DESCRIPTION
If someone is given access to a flathub/* repo on GitHub, they can click Refresh instead of logging out and back in. We can also use the function in other places if we want to make sure the repo list for a user is up to date.