### PR TITLE
Allow compat endpoint to pick better biggest/smallest image 

### DIFF
--- a/backend/app/compat.py
+++ b/backend/app/compat.py
@@ -209,24 +209,25 @@ def get_single_app(appid: str, background_tasks: BackgroundTasks):
 
             screenshots = list(filter(None, screenshots))
 
-            screenshots_sizes = sorted(
-                screenshots[0].keys(), key=lambda res: int(res.split("x")[0])
-            )
-            if screenshots_sizes:
-                full_size = screenshots_sizes[-1]
-                thumb_size = screenshots_sizes[0]
+            compat_screenshots = []
+            for screenshot in screenshots:
+                screenshots_sizes = sorted(
+                    screenshot.keys(), key=lambda res: int(res.split("x")[0])
+                )
 
-                compat_screenshots = []
-                for screenshot in screenshots:
-                    filename = list(screenshot.values())[0].split("/")[-1]
-                    compat_screenshots.append(
-                        {
-                            "imgDesktopUrl": f"https://dl.flathub.org/repo/screenshots/{appid}-stable/{full_size}/{filename}",
-                            "imgMobileUrl": f"https://dl.flathub.org/repo/screenshots/{appid}-stable/{full_size}/{filename}",
-                            "thumbUrl": f"https://dl.flathub.org/repo/screenshots/{appid}-stable/{thumb_size}/{filename}",
-                        }
-                    )
-                compat_app["screenshots"] = compat_screenshots
+                if screenshots_sizes:
+                    full_size = screenshots_sizes[-1]
+                    thumb_size = screenshots_sizes[0]
+
+                filename = list(screenshot.values())[0].split("/")[-1]
+                compat_screenshots.append(
+                    {
+                        "imgDesktopUrl": f"https://dl.flathub.org/repo/screenshots/{appid}-stable/{full_size}/{filename}",
+                        "imgMobileUrl": f"https://dl.flathub.org/repo/screenshots/{appid}-stable/{full_size}/{filename}",
+                        "thumbUrl": f"https://dl.flathub.org/repo/screenshots/{appid}-stable/{thumb_size}/{filename}",
+                    }
+                )
+            compat_app["screenshots"] = compat_screenshots
 
         return compat_app
 


### PR DESCRIPTION
This causes the route to fail and is actually the most prominent bug we have
in sentry right now.