### PR TITLE
Show release extender later

### DIFF
--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -40,6 +40,7 @@ import { getAppVendingSetup } from "../../asyncs/vending"
 import useCollapse from "react-collapsed"
 import { VerificationStatus } from "src/types/VerificationStatus"
 import { motion } from "framer-motion"
+import { classNames } from "src/styling"
 
 interface Props {
   app?: Appstream
@@ -244,7 +245,12 @@ const Details: FunctionComponent<Props> = ({
             {scrollHeight > collapsedHeight && (
               <div
                 {...getCollapseProps()}
-                className={`prose dark:prose-invert xl:max-w-[75%]`}
+                className={classNames(
+                  `prose relative transition-all dark:prose-invert xl:max-w-[75%]`,
+                  !isExpanded && scrollHeight > collapsedHeight
+                    ? "from-transparent to-flathub-white before:absolute before:left-0 before:top-0 before:h-full before:w-full before:bg-gradient-to-b before:content-[''] dark:to-flathub-dark-gunmetal"
+                    : "",
+                )}
                 ref={ref}
                 dangerouslySetInnerHTML={{
                   __html: description,

--- a/frontend/src/components/application/Releases.tsx
+++ b/frontend/src/components/application/Releases.tsx
@@ -5,13 +5,14 @@ import { getIntlLocale, getLocale } from "../../localize"
 
 import { Release } from "../../types/Appstream"
 import useCollapse from "react-collapsed"
+import { classNames } from "src/styling"
 
 interface Props {
   latestRelease: Release | null
 }
 
 const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
-  const collapsedHeight = 60
+  const collapsedHeight = 62
   const [scrollHeight, setScrollHeight] = useState(0)
   const ref = useRef(null)
 
@@ -84,11 +85,12 @@ const Releases: FunctionComponent<Props> = ({ latestRelease }) => {
               </header>
               <div
                 {...getCollapseProps()}
-                className={`prose relative transition-all duration-700 dark:prose-invert ${
+                className={classNames(
+                  `prose relative transition-all duration-700 dark:prose-invert`,
                   !isExpanded && scrollHeight > collapsedHeight
                     ? "from-transparent to-flathub-white before:absolute before:left-0 before:top-0 before:h-full before:w-full before:bg-gradient-to-b before:content-[''] dark:to-flathub-arsenic"
-                    : ""
-                }`}
+                    : "",
+                )}
                 ref={ref}
                 dangerouslySetInnerHTML={{
                   __html: releaseDescription,


### PR DESCRIPTION
The previous start height, was too low and lead to
 empty boxes flip flopping.
As the height could be 61 or 60.