### PR TITLE
DRAFT: Add consultants page

### DIFF
--- a/frontend/pages/consultants.tsx
+++ b/frontend/pages/consultants.tsx
@@ -1,0 +1,68 @@
+import { GetStaticProps } from "next"
+import { useTranslation } from "next-i18next"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
+import { NextSeo } from "next-seo"
+import { fetchStats } from "../src/fetchers"
+
+const Consultants = (): JSX.Element => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <NextSeo
+        title={t("consultants")}
+        description={t("consultants-description")}
+      />
+      <div className="prose flex max-w-full flex-col px-[5%] text-justify dark:prose-invert md:px-[20%] 2xl:px-[30%]">
+        <h1 className="my-8">Consultants and Contractors</h1>
+
+        <p>
+          Developers who are interested in publishing their app on Flathub may
+          want some technical assistance with the process of preparing and
+          submitting their app to Flathub. Below, we have some companies and
+          individuals that offer consulting services for preparing a Flatpak
+          build of an app and submitting it to Flathub. Typically, they would
+          support the submission of an app which already has a working Linux
+          version.
+        </p>
+
+        <p>
+          All companies and individuals listed below are familiar to the Flathub
+          team, have successfully submitted at least one app to Flathub, and
+          actively maintain at least one app on Flathub. Beyond this,
+          <strong>the Flathub team has done no checks on them</strong>. Please
+          contact them directly if you would like to know more about the
+          services that they provide.
+        </p>
+
+        <h2>Flatty McPakface, LLC</h2>
+
+        <p>
+          Flatty McPakface is a boutique software consultancy, based on the
+          Great Pacific Garbage Patch. As well as maintaining Poorly-Planned
+          Audience Polls on Flathub, we have contributed a number of features to
+          Flatpak itself, including the recycling portal.
+        </p>
+
+        <p>
+          <a href="https://flattymcpakface.example.com/">More details</a>
+        </p>
+      </div>
+    </>
+  )
+}
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  console.log("Fetching data for stats")
+  const stats = await fetchStats()
+
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ["common"])),
+      stats,
+    },
+    revalidate: 900,
+  }
+}
+
+export default Consultants

--- a/frontend/pages/consultants.tsx
+++ b/frontend/pages/consultants.tsx
@@ -35,17 +35,17 @@ const Consultants = (): JSX.Element => {
           services that they provide.
         </p>
 
-        <h2>Flatty McPakface, LLC</h2>
+        <h2>Hari Rana</h2>
 
         <p>
-          Flatty McPakface is a boutique software consultancy, based on the
-          Great Pacific Garbage Patch. As well as maintaining Poorly-Planned
-          Audience Polls on Flathub, we have contributed a number of features to
-          Flatpak itself, including the recycling portal.
-        </p>
-
-        <p>
-          <a href="https://flattymcpakface.example.com/">More details</a>
+          Hari Rana is a Flatpak, GNOME and Fedora contributor; the
+          co-maintainer of <a href="https://usebottles.com/">Bottles</a> and
+          <a href="https://gitlab.com/TheEvilSkeleton/Upscaler">Upscaler</a>;
+          and a member of <a href="https://vanillaos.org/">Vanilla OS</a>, a
+          Flatpak-centric distribution. He maintains a number of apps on
+          Flathub, including three Chromium-based web browsers. See
+          <a href="https://theevilskeleton.gitlab.io/">his website</a> for more
+          details and contact information.
         </p>
       </div>
     </>

--- a/frontend/pages/consultants.tsx
+++ b/frontend/pages/consultants.tsx
@@ -2,7 +2,6 @@ import { GetStaticProps } from "next"
 import { useTranslation } from "next-i18next"
 import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NextSeo } from "next-seo"
-import { fetchStats } from "../src/fetchers"
 
 const Consultants = (): JSX.Element => {
   const { t } = useTranslation()
@@ -12,6 +11,9 @@ const Consultants = (): JSX.Element => {
       <NextSeo
         title={t("consultants")}
         description={t("consultants-description")}
+        openGraph={{
+          url: `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/consultants`,
+        }}
       />
       <div className="prose flex max-w-full flex-col px-[5%] text-justify dark:prose-invert md:px-[20%] 2xl:px-[30%]">
         <h1 className="my-8">Consultants and Contractors</h1>
@@ -95,13 +97,9 @@ const Consultants = (): JSX.Element => {
 }
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
-  console.log("Fetching data for stats")
-  const stats = await fetchStats()
-
   return {
     props: {
       ...(await serverSideTranslations(locale, ["common"])),
-      stats,
     },
     revalidate: 900,
   }

--- a/frontend/pages/consultants.tsx
+++ b/frontend/pages/consultants.tsx
@@ -47,6 +47,16 @@ const Consultants = (): JSX.Element => {
           <a href="https://theevilskeleton.gitlab.io/">his website</a> for more
           details and contact information.
         </p>
+
+        <h2>Mazhar Hussain</h2>
+
+        <p>
+          Mazhar Hussain is the primary author of
+          <a href="https://gdm-settings.github.io/">Login Manager Settings</a>,
+          a settings app for GNOME's login manager, which is published on
+          Flathub. See
+          <a href="https://realmazharhussain.github.io/">his website</a> for
+          more details and contact information.
       </div>
     </>
   )

--- a/frontend/pages/consultants.tsx
+++ b/frontend/pages/consultants.tsx
@@ -29,7 +29,7 @@ const Consultants = (): JSX.Element => {
         <p>
           All companies and individuals listed below are familiar to the Flathub
           team, have successfully submitted at least one app to Flathub, and
-          actively maintain at least one app on Flathub. Beyond this,
+          actively maintain at least one app on Flathub. Beyond this,{" "}
           <strong>the Flathub team has done no checks on them</strong>. Please
           contact them directly if you would like to know more about the
           services that they provide.
@@ -38,25 +38,57 @@ const Consultants = (): JSX.Element => {
         <h2>Hari Rana</h2>
 
         <p>
-          Hari Rana is a Flatpak, GNOME and Fedora contributor; the
-          co-maintainer of <a href="https://usebottles.com/">Bottles</a> and
-          <a href="https://gitlab.com/TheEvilSkeleton/Upscaler">Upscaler</a>;
-          and a member of <a href="https://vanillaos.org/">Vanilla OS</a>, a
-          Flatpak-centric distribution. He maintains a number of apps on
-          Flathub, including three Chromium-based web browsers. See
-          <a href="https://theevilskeleton.gitlab.io/">his website</a> for more
-          details and contact information.
+          Hari Rana is a Flatpak, GNOME and Fedora contributor, the
+          co-maintainer of{" "}
+          <a target="_blank" rel="noreferrer" href="https://usebottles.com/">
+            Bottles
+          </a>{" "}
+          and{" "}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://gitlab.com/TheEvilSkeleton/Upscaler"
+          >
+            Upscaler
+          </a>{" "}
+          and and a member of{" "}
+          <a target="_blank" rel="noreferrer" href="https://vanillaos.org/">
+            Vanilla OS
+          </a>
+          , a Flatpak-centric distribution. He maintains a number of apps on
+          Flathub, including three Chromium-based web browsers. See{" "}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://theevilskeleton.gitlab.io/"
+          >
+            his website
+          </a>{" "}
+          for more details and contact information.
         </p>
 
         <h2>Mazhar Hussain</h2>
 
         <p>
-          Mazhar Hussain is the primary author of
-          <a href="https://gdm-settings.github.io/">Login Manager Settings</a>,
-          a settings app for GNOME's login manager, which is published on
-          Flathub. See
-          <a href="https://realmazharhussain.github.io/">his website</a> for
-          more details and contact information.
+          Mazhar Hussain is the primary author of{" "}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://gdm-settings.github.io/"
+          >
+            Login Manager Settings
+          </a>
+          , a settings app for GNOME&apos;s login manager, which is published on
+          Flathub. See{" "}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href="https://realmazharhussain.github.io/"
+          >
+            his website
+          </a>{" "}
+          for more details and contact information.
+        </p>
       </div>
     </>
   )

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -202,6 +202,8 @@
   "privacy-policy-description": "By using this website, you agree to the Privacy Policy.",
   "terms-and-conditions": "Terms and conditions",
   "terms-and-conditions-description": "By using this website, you agree to the Terms and Conditions.",
+  "consultants": "Consultants",
+  "consultants-description": "Consulting services for submitting apps to Flathub.",
   "continue": "Continue",
   "purchase-terms-confirmation": "I confirm that I have read the Flathub Terms & Conditions and consent to waiving the 14-day cooling off period associated with this digital download.",
   "contribute-languages": "All these translations have been contributed by the community. If you want to help translate Flathub, please <1>join the Flathub translation team</1>.",

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -156,6 +156,12 @@ const Footer = () => {
             >
               {t("about")}
             </Link>
+            <Link
+              href="/consultants"
+              className="flex h-12 items-center justify-center text-xl text-inherit hover:underline sm:block sm:h-auto sm:text-sm"
+            >
+              {t("consultants")}
+            </Link>
             <a
               className="flex h-12 items-center justify-center text-center text-xl text-inherit hover:underline sm:block sm:h-auto sm:text-start sm:text-sm"
               href="https://status.flathub.org/"


### PR DESCRIPTION
I recently had cause to want to recommend a freelancer to an organisation that is interested in submitting their app to Flathub, but which has no in-house Flatpak expertise. I put out a call on social media and a number of people responded.

Inspired by the [Consulting Services for fwupd and the LVFS][0] page, I would like to add a page to the Flathub website which serves as an index of consultants and freelancers who offer paid services to help submit & maintain apps on Flathub. My suggestion is that people & companies who wish to be on this list should submit themselves in PR form, and this would be approved by a Flathub app reviewer as well as the website maintainers. I have shamelessly adapted some wording from the fwupd page to make clear that Flathub has not actually vetted these people beyond the fact that they have navigated the app submission gauntlet. The requirements I laid out are, of course, open to discussion!

I have not actually tested this PR. I tried and failed to install `yarn` and gave up.

Another idea I had was that the list should be in a random order, perhaps seeded by the current date so that it remains consistent on any given day. I don't know Typescript or JSX well enough (or at all) to implement that myself.

[0]: https://fwupd.org/lvfs/docs/consulting