### PR TITLE
Uses boring-avatars as fallback if user avatar is null

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "@sentry/nextjs": "^7.45.0",
     "@stripe/react-stripe-js": "^2.1.0",
     "@stripe/stripe-js": "^1.52.1",
+    "boring-avatars": "^1.7.0",
     "chart.js": "^4.2.1",
     "chartjs-adapter-date-fns": "^3.0.0",
     "clsx": "^1.2.1",

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/router"
 import { HiMagnifyingGlass, HiXMark, HiBars3 } from "react-icons/hi2"
 
 import { LogoJsonLd, SiteLinksSearchBoxJsonLd } from "next-seo"
-import { env } from "process"
+import Avatar from "boring-avatars"
 import { useTranslation } from "next-i18next"
 import { IS_PRODUCTION } from "../../env"
 import { useUserContext, useUserDispatch } from "../../context/user-info"
@@ -37,6 +37,7 @@ const Header = () => {
   const router = useRouter()
   const user = useUserContext()
 
+  const [userAvatarUrl, setUserAvatarUrl] = useState<string | null>(null)
   const [query, setQuery] = useState("")
 
   const [clickedLogout, setClickedLogout] = useState(false)
@@ -54,6 +55,16 @@ const Header = () => {
       setClickedLogout(false)
     }
   }, [clickedLogout, dispatch, t])
+
+  useEffect(() => {
+    if (user.info) {
+      const avatarUrl = Object.values(user.info.auths).find(
+        (auth) => auth.avatar,
+      ).avatar
+
+      setUserAvatarUrl(avatarUrl)
+    }
+  }, [user.info])
 
   useEffect(() => {
     document.dir = i18n.dir()
@@ -248,19 +259,27 @@ const Header = () => {
                       <div>
                         <Menu.Button className="flex rounded-full bg-white">
                           <span className="sr-only">{t("open-user-menu")}</span>
-                          <Image
-                            className="rounded-full"
-                            src={
-                              Object.values(user.info.auths).find(
-                                (auth) => auth.avatar,
-                              ).avatar
-                            }
-                            width="38"
-                            height="38"
-                            alt={t("user-avatar", {
-                              user: user.info.displayname,
-                            })}
-                          />
+                          {userAvatarUrl ? (
+                            <Image
+                              className="rounded-full"
+                              src={userAvatarUrl}
+                              width="38"
+                              height="38"
+                              alt={t("user-avatar", {
+                                user: user.info.displayname,
+                              })}
+                            />
+                          ) : (
+                            <Avatar
+                              size={40}
+                              name={user.info.displayname}
+                              variant="marble"
+                              colors={[
+                                "rgb(74, 144, 217)",
+                                "rgb(112, 222, 230)",
+                              ]}
+                            />
+                          )}
                         </Menu.Button>
                       </div>
                       <Transition

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -4,7 +4,6 @@ import { useRouter } from "next/router"
 import { HiMagnifyingGlass, HiXMark, HiBars3 } from "react-icons/hi2"
 
 import { LogoJsonLd, SiteLinksSearchBoxJsonLd } from "next-seo"
-import Avatar from "boring-avatars"
 import { useTranslation } from "next-i18next"
 import { IS_PRODUCTION } from "../../env"
 import { useUserContext, useUserDispatch } from "../../context/user-info"
@@ -16,6 +15,7 @@ import { logout } from "src/asyncs/login"
 import { clsx } from "clsx"
 import { FlathubLogo } from "../login/FlathubLogo"
 import { FlathubMiniLogo } from "../login/FlathubLogoMini"
+import Avatar from "../user/Avatar"
 
 const navigation = [
   {
@@ -259,27 +259,10 @@ const Header = () => {
                       <div>
                         <Menu.Button className="flex rounded-full bg-white">
                           <span className="sr-only">{t("open-user-menu")}</span>
-                          {userAvatarUrl ? (
-                            <Image
-                              className="rounded-full"
-                              src={userAvatarUrl}
-                              width="38"
-                              height="38"
-                              alt={t("user-avatar", {
-                                user: user.info.displayname,
-                              })}
-                            />
-                          ) : (
-                            <Avatar
-                              size={40}
-                              name={user.info.displayname}
-                              variant="marble"
-                              colors={[
-                                "rgb(74, 144, 217)",
-                                "rgb(112, 222, 230)",
-                              ]}
-                            />
-                          )}
+                          <Avatar
+                            userName={user.info.displayname}
+                            avatarUrl={userAvatarUrl}
+                          />
                         </Menu.Button>
                       </div>
                       <Transition

--- a/frontend/src/components/user/Avatar.tsx
+++ b/frontend/src/components/user/Avatar.tsx
@@ -1,0 +1,38 @@
+import Image from "next/image"
+import { FunctionComponent } from "react"
+import FallbackAvatar from "boring-avatars"
+import { useTranslation } from "next-i18next"
+
+interface Props {
+  avatarUrl: string | null
+  userName: string
+}
+
+const celestialBlue = "#4a90d9"
+const variationTone = "#70dee6"
+
+const Avatar: FunctionComponent<Props> = (props: Props) => {
+  const { avatarUrl, userName } = props
+  const { t } = useTranslation()
+
+  return avatarUrl ? (
+    <Image
+      className="rounded-full"
+      src={avatarUrl}
+      width="38"
+      height="38"
+      alt={t("user-avatar", {
+        user: userName,
+      })}
+    />
+  ) : (
+    <FallbackAvatar
+      size={38}
+      name={userName}
+      variant="marble"
+      colors={[celestialBlue, variationTone]}
+    />
+  )
+}
+
+export default Avatar

--- a/frontend/src/components/user/Details.tsx
+++ b/frontend/src/components/user/Details.tsx
@@ -4,6 +4,7 @@ import { FunctionComponent } from "react"
 import { useUserContext } from "../../context/user-info"
 import { LoginProvider } from "../../types/Login"
 import ProviderLink from "../login/ProviderLink"
+import Avatar from "boring-avatars"
 
 interface Props {
   logins: LoginProvider[]
@@ -29,13 +30,22 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
           key={provider.method}
           className="flex w-full items-center gap-3 rounded-xl bg-flathub-white px-4 py-4 text-flathub-dark-gunmetal shadow-md  dark:bg-flathub-dark-gunmetal dark:text-flathub-gainsborow md:w-auto"
         >
-          <Image
-            src={authData.avatar}
-            width={48}
-            height={48}
-            className="rounded-full"
-            alt={t("user-avatar", { user: authData.login })}
-          />
+          {authData.avatar ? (
+            <Image
+              src={authData.avatar}
+              width={48}
+              height={48}
+              className="rounded-full"
+              alt={t("user-avatar", { user: authData.login })}
+            />
+          ) : (
+            <Avatar
+              size={40}
+              name={user.info.displayname}
+              variant="marble"
+              colors={["rgb(74, 144, 217)", "rgb(112, 222, 230)"]}
+            />
+          )}
           <div className="flex flex-col">
             <span className="font-semibold">{provider.name}</span>
             <span>{authData.login}</span>

--- a/frontend/src/components/user/Details.tsx
+++ b/frontend/src/components/user/Details.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from "next-i18next"
-import Image from "next/image"
 import { FunctionComponent } from "react"
 import { useUserContext } from "../../context/user-info"
 import { LoginProvider } from "../../types/Login"
 import ProviderLink from "../login/ProviderLink"
-import Avatar from "boring-avatars"
+import Avatar from "./Avatar"
 
 interface Props {
   logins: LoginProvider[]
@@ -30,22 +29,10 @@ const UserDetails: FunctionComponent<Props> = ({ logins }) => {
           key={provider.method}
           className="flex w-full items-center gap-3 rounded-xl bg-flathub-white px-4 py-4 text-flathub-dark-gunmetal shadow-md  dark:bg-flathub-dark-gunmetal dark:text-flathub-gainsborow md:w-auto"
         >
-          {authData.avatar ? (
-            <Image
-              src={authData.avatar}
-              width={48}
-              height={48}
-              className="rounded-full"
-              alt={t("user-avatar", { user: authData.login })}
-            />
-          ) : (
-            <Avatar
-              size={40}
-              name={user.info.displayname}
-              variant="marble"
-              colors={["rgb(74, 144, 217)", "rgb(112, 222, 230)"]}
-            />
-          )}
+          <Avatar
+            userName={user.info.displayname}
+            avatarUrl={authData.avatar}
+          />
           <div className="flex flex-col">
             <span className="font-semibold">{provider.name}</span>
             <span>{authData.login}</span>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4238,6 +4238,11 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
+boring-avatars@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/boring-avatars/-/boring-avatars-1.7.0.tgz#70ac7146bbf37d8e69a35544b24f1d75558f868a"
+  integrity sha512-ZNHd8J7C/V0IjQMGQowLJ5rScEFU23WxePigH6rqKcT2Esf0qhYvYxw8s9i3srmlfCnCV00ddBjaoGey1eNOfA==
+
 boxen@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.2.tgz#788cb686fc83c1f486dfa8a40c68fc2b831d2b50"


### PR DESCRIPTION
Addresses [this issue](https://github.com/flathub/website/issues/1366). If the avatar is null, it will use a randomly generated avatar via the `boring-avatars` package. These avatars are generated at runtime, and not being fetched from a remote source.

The end result looks like this if the user's avatar comes off as `null`:

![Screenshot from 2023-04-23 15-49-51](https://user-images.githubusercontent.com/23466083/233868358-91afbc0e-4f8d-4fcb-8002-1927f90c9e10.png)


Note that the pattern depends on the user's name; mine happens to look like that.