### PR TITLE
Highlight proprietary license in app details page

### DIFF
--- a/frontend/src/components/application/AdditionalInfo.tsx
+++ b/frontend/src/components/application/AdditionalInfo.tsx
@@ -12,6 +12,7 @@ import {
   HiInbox,
   HiLanguage,
   HiLifebuoy,
+  HiMinusCircle,
   HiScale,
   HiWrenchScrewdriver,
 } from "react-icons/hi2"
@@ -39,6 +40,9 @@ const AdditionalInfo = ({
 
   const licenseIsLink = data.project_license?.startsWith(
     "LicenseRef-proprietary=",
+  )
+  const licenseIsProprietary = data.project_license?.startsWith(
+    "LicenseRef-proprietary",
   )
 
   return (
@@ -110,8 +114,13 @@ const AdditionalInfo = ({
           appId={appId}
           items={[
             {
-              icon: <HiScale />,
+              icon: licenseIsProprietary ? (
+                <HiMinusCircle color="rgb(var(--flathub-electric-red))" />
+              ) : (
+                <HiScale />
+              ),
               header: t("license"),
+              highlight: licenseIsProprietary,
               content: {
                 type: licenseIsLink ? "url" : "text",
                 text: license,

--- a/frontend/src/components/application/ListBox.tsx
+++ b/frontend/src/components/application/ListBox.tsx
@@ -52,7 +52,11 @@ const ListBox: FunctionComponent<Props> = ({ appId, items }) => {
                 <div className="text-base">
                   {item.header}
                   {item.content.type === "text" && (
-                    <span className="block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-flathub-sonic-silver dark:text-flathub-spanish-gray">
+                    <span
+                      className={`block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-flathub-sonic-silver dark:text-flathub-spanish-gray ${
+                        item.highlight ? "text-flathub-granite-gray" : "" // increase contrast with highlighted background
+                      }`}
+                    >
                       {item.content.text}
                     </span>
                   )}
@@ -63,7 +67,7 @@ const ListBox: FunctionComponent<Props> = ({ appId, items }) => {
                       rel="noreferrer"
                       onClick={linkClicked}
                       className={`block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-flathub-sonic-silver no-underline hover:underline dark:text-flathub-spanish-gray ${
-                        item.highlight ? "text-flathub-granite-gray" : "" // increase contrast with highlighted background
+                        item.highlight ? "text-flathub-granite-gray" : ""
                       }`}
                     >
                       {item.content.text}

--- a/frontend/src/components/application/ListBox.tsx
+++ b/frontend/src/components/application/ListBox.tsx
@@ -8,6 +8,7 @@ interface Props {
   items: {
     icon: string | JSX.Element
     header: string
+    highlight?: boolean
     content:
       | { type: "url"; text: string; trackAsEvent: string }
       | { type: "text"; text: string }
@@ -38,6 +39,10 @@ const ListBox: FunctionComponent<Props> = ({ appId, items }) => {
                   item.content.type === "text"
                     ? "grid-cols-[36px_calc(100%_-_36px)]"
                     : ""
+                } ${
+                  item.highlight
+                    ? "bg-flathub-electric-red/10 ring-2 ring-flathub-electric-red/50 dark:bg-flathub-electric-red/30"
+                    : ""
                 }`}
                 key={index}
               >
@@ -57,7 +62,9 @@ const ListBox: FunctionComponent<Props> = ({ appId, items }) => {
                       target="_blank"
                       rel="noreferrer"
                       onClick={linkClicked}
-                      className="block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-flathub-sonic-silver no-underline hover:underline dark:text-flathub-spanish-gray"
+                      className={`block w-full overflow-hidden text-ellipsis whitespace-nowrap text-xs text-flathub-sonic-silver no-underline hover:underline dark:text-flathub-spanish-gray ${
+                        item.highlight ? "text-flathub-granite-gray" : "" // increase contrast with highlighted background
+                      }`}
                     >
                       {item.content.text}
                     </a>


### PR DESCRIPTION
Hi! This is my first PR in this repo, sorry if I did things how you usually wouldn't.

To start with something simple, I went for the second part of #1365, "if a software is proprietary software maybe it could show "Proprietary" in red color and/or with a warning icon".

I tried eyeballing the colors to find a pleasant match that draws attention yet doesn't distract too much, I think I got it alright:

![Screen Shot 2023-04-28 at 17 43 54](https://user-images.githubusercontent.com/2021487/235195942-09293e73-58e8-4290-9925-0cc50a06967e.png)

To keep contrast between background and text according to WCAG, I also had to adjust the "subtext" (link/text) color when the ListBox is highlighted.

I was thinking of adding some sort of 🛈 icon that on hover would show a popup that explains the downsides of proprietary software because new users who don't know what proprietary means might be confused. Thoughts?