### PR TITLE
Filter search page for Free Software only

### DIFF
--- a/backend/app/apps.py
+++ b/backend/app/apps.py
@@ -1,7 +1,7 @@
 import json
 import re
-import gi
 
+import gi
 from gi.repository import AppStream
 
 from . import db, search, utils

--- a/backend/app/apps.py
+++ b/backend/app/apps.py
@@ -1,7 +1,12 @@
 import json
 import re
+import gi
+
+from gi.repository import AppStream
 
 from . import db, search, utils
+
+gi.require_version("AppStream", "1.0")
 
 
 def load_appstream():
@@ -24,6 +29,8 @@ def load_appstream():
 
             search_keywords = apps[appid].get("keywords")
 
+            project_license = apps[appid].get("project_license", "")
+
             # order of the dict is important for attritbute ranking
             search_apps.append(
                 {
@@ -31,6 +38,8 @@ def load_appstream():
                     "name": apps[appid]["name"],
                     "summary": apps[appid]["summary"],
                     "keywords": search_keywords,
+                    "project_license": project_license,
+                    "is_free_license": AppStream.license_is_free_license(project_license),
                     "app_id": appid,
                     "description": search_description,
                     "icon": apps[appid]["icon"],

--- a/backend/app/apps.py
+++ b/backend/app/apps.py
@@ -39,7 +39,9 @@ def load_appstream():
                     "summary": apps[appid]["summary"],
                     "keywords": search_keywords,
                     "project_license": project_license,
-                    "is_free_license": AppStream.license_is_free_license(project_license),
+                    "is_free_license": AppStream.license_is_free_license(
+                        project_license
+                    ),
                     "app_id": appid,
                     "description": search_description,
                     "icon": apps[appid]["icon"],

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -181,8 +181,8 @@ def get_appstream(appid: str, response: Response):
 
 
 @app.get("/search/{userquery}")
-def get_search(userquery: str):
-    return search.search_apps(userquery)
+def get_search(userquery: str, free_software_only: bool = False):
+    return search.search_apps(userquery, free_software_only)
 
 
 @app.get("/collection/recently-updated")

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -15,7 +15,13 @@ client.index("apps").update_searchable_attributes(
     ["name", "summary", "keywords", "description", "id"]
 )
 client.index("apps").update_filterable_attributes(
-    ["categories", "developer_name", "project_group", "verification_verified", "is_free_license"]
+    [
+        "categories",
+        "developer_name",
+        "project_group",
+        "verification_verified",
+        "is_free_license",
+    ]
 )
 
 
@@ -130,7 +136,8 @@ def search_apps(query: str, free_software_only: bool):
     return client.index("apps").search(
         query,
         {
-            "limit": 250, "sort": ["installs_last_month:desc"],
+            "limit": 250,
+            "sort": ["installs_last_month:desc"],
             "filter": ["is_free_license = true"] if free_software_only else None,
-        }
+        },
     )

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -15,7 +15,7 @@ client.index("apps").update_searchable_attributes(
     ["name", "summary", "keywords", "description", "id"]
 )
 client.index("apps").update_filterable_attributes(
-    ["categories", "developer_name", "project_group", "verification_verified"]
+    ["categories", "developer_name", "project_group", "verification_verified", "is_free_license"]
 )
 
 

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -130,7 +130,7 @@ def get_by_project_group(project_group: str, page: int, hits_per_page: int):
     )
 
 
-def search_apps(query: str, free_software_only: bool):
+def search_apps(query: str, free_software_only: bool = False):
     query = unquote(query)
 
     return client.index("apps").search(

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -124,9 +124,13 @@ def get_by_project_group(project_group: str, page: int, hits_per_page: int):
     )
 
 
-def search_apps(query: str):
+def search_apps(query: str, free_software_only: bool):
     query = unquote(query)
 
     return client.index("apps").search(
-        query, {"limit": 250, "sort": ["installs_last_month:desc"]}
+        query,
+        {
+            "limit": 250, "sort": ["installs_last_month:desc"],
+            "filter": ["is_free_license = true"] if free_software_only else None,
+        }
     )

--- a/backend/tests/results/test_apps_by_category.json
+++ b/backend/tests/results/test_apps_by_category.json
@@ -7,6 +7,7 @@
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
       "installs_last_month": 467,
+      "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
       "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
       "categories": [
@@ -14,6 +15,7 @@
       ],
       "developer_name": "Sugar Labs Community",
       "project_group": "SugarLabs",
+      "project_license": "GPL-3.0-or-later",
       "verification_verified": null,
       "verification_method": null,
       "verification_login_is_organization": null,

--- a/backend/tests/results/test_apps_by_developer.json
+++ b/backend/tests/results/test_apps_by_developer.json
@@ -1,34 +1,36 @@
 {
-    "hits": [
-      {
-        "name": "Maze",
-        "summary": "A simple maze game",
-        "keywords": null,
-        "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
-        "id": "org_sugarlabs_Maze",
-        "installs_last_month": 467,
-        "app_id": "org.sugarlabs.Maze",
-        "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
-        "categories": [
-          "Game"
-        ],
-        "developer_name": "Sugar Labs Community",
-        "project_group": "SugarLabs",
-        "verification_verified": null,
-        "verification_method": null,
-        "verification_login_is_organization": null,
-        "verification_login_name": null,
-        "verification_login_provider": null,
-        "verification_website": null,
-        "verification_timestamp": null,
-        "updated_at": 1610973680,
-        "added_at": 1610973680
-      }
-    ],
-    "query": "",
-    "processingTimeMs": 0,
-    "hitsPerPage": 250,
-    "page": 1,
-    "totalPages": 1,
-    "totalHits": 1
-  }
+  "hits": [
+    {
+      "name": "Maze",
+      "summary": "A simple maze game",
+      "keywords": null,
+      "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
+      "id": "org_sugarlabs_Maze",
+      "installs_last_month": 467,
+      "is_free_license": true,
+      "app_id": "org.sugarlabs.Maze",
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "developer_name": "Sugar Labs Community",
+      "project_group": "SugarLabs",
+      "project_license": "GPL-3.0-or-later",
+      "verification_verified": null,
+      "verification_method": null,
+      "verification_login_is_organization": null,
+      "verification_login_name": null,
+      "verification_login_provider": null,
+      "verification_website": null,
+      "verification_timestamp": null,
+      "updated_at": 1610973680,
+      "added_at": 1610973680
+    }
+  ],
+  "query": "",
+  "processingTimeMs": 0,
+  "hitsPerPage": 250,
+  "page": 1,
+  "totalPages": 1,
+  "totalHits": 1
+}

--- a/backend/tests/results/test_apps_by_projectgroup.json
+++ b/backend/tests/results/test_apps_by_projectgroup.json
@@ -1,34 +1,36 @@
 {
-    "hits": [
-      {
-        "name": "Maze",
-        "summary": "A simple maze game",
-        "keywords": null,
-        "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
-        "id": "org_sugarlabs_Maze",
-        "installs_last_month": 467,
-        "app_id": "org.sugarlabs.Maze",
-        "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
-        "categories": [
-          "Game"
-        ],
-        "developer_name": "Sugar Labs Community",
-        "project_group": "SugarLabs",
-        "verification_verified": null,
-        "verification_method": null,
-        "verification_login_is_organization": null,
-        "verification_login_name": null,
-        "verification_login_provider": null,
-        "verification_website": null,
-        "verification_timestamp": null,
-        "updated_at": 1610973680,
-        "added_at": 1610973680
-      }
-    ],
-    "query": "",
-    "processingTimeMs": 0,
-    "hitsPerPage": 250,
-    "page": 1,
-    "totalPages": 1,
-    "totalHits": 1
-  }
+  "hits": [
+    {
+      "name": "Maze",
+      "summary": "A simple maze game",
+      "keywords": null,
+      "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
+      "id": "org_sugarlabs_Maze",
+      "installs_last_month": 467,
+      "is_free_license": true,
+      "app_id": "org.sugarlabs.Maze",
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "developer_name": "Sugar Labs Community",
+      "project_group": "SugarLabs",
+      "project_license": "GPL-3.0-or-later",
+      "verification_verified": null,
+      "verification_method": null,
+      "verification_login_is_organization": null,
+      "verification_login_name": null,
+      "verification_login_provider": null,
+      "verification_website": null,
+      "verification_timestamp": null,
+      "updated_at": 1610973680,
+      "added_at": 1610973680
+    }
+  ],
+  "query": "",
+  "processingTimeMs": 0,
+  "hitsPerPage": 250,
+  "page": 1,
+  "totalPages": 1,
+  "totalHits": 1
+}

--- a/backend/tests/results/test_collection_by_one_recently_updated.json
+++ b/backend/tests/results/test_collection_by_one_recently_updated.json
@@ -7,6 +7,7 @@
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
       "installs_last_month": 613,
+      "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
       "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
       "categories": [
@@ -14,6 +15,7 @@
       ],
       "developer_name": "AnyDesk Software GmbH",
       "project_group": null,
+      "project_license": "LicenseRef-proprietary",
       "verification_verified": null,
       "verification_method": null,
       "verification_login_is_organization": null,

--- a/backend/tests/results/test_collection_by_recently_updated.json
+++ b/backend/tests/results/test_collection_by_recently_updated.json
@@ -7,6 +7,7 @@
       "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
       "id": "com_anydesk_Anydesk",
       "installs_last_month": 613,
+      "is_free_license": false,
       "app_id": "com.anydesk.Anydesk",
       "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
       "categories": [
@@ -14,6 +15,7 @@
       ],
       "developer_name": "AnyDesk Software GmbH",
       "project_group": null,
+      "project_license": "LicenseRef-proprietary",
       "verification_verified": null,
       "verification_method": null,
       "verification_login_is_organization": null,
@@ -31,6 +33,7 @@
       "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
       "id": "com_wps_Office",
       "installs_last_month": 668,
+      "is_free_license": false,
       "app_id": "com.wps.Office",
       "icon": "https://www.wps.com/assets/mediahub/WPS-Office-Mobile.png",
       "categories": [
@@ -38,6 +41,7 @@
       ],
       "developer_name": "Kingsoft Office Corporation",
       "project_group": null,
+      "project_license": "LicenseRef-proprietary=http://wps-community.org/license.md",
       "verification_verified": null,
       "verification_method": null,
       "verification_login_is_organization": null,
@@ -55,6 +59,7 @@
       "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
       "id": "org_sugarlabs_Maze",
       "installs_last_month": 467,
+      "is_free_license": true,
       "app_id": "org.sugarlabs.Maze",
       "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
       "categories": [
@@ -62,6 +67,7 @@
       ],
       "developer_name": "Sugar Labs Community",
       "project_group": "SugarLabs",
+      "project_license": "GPL-3.0-or-later",
       "verification_verified": null,
       "verification_method": null,
       "verification_login_is_organization": null,

--- a/backend/tests/results/test_popular_last_month.json
+++ b/backend/tests/results/test_popular_last_month.json
@@ -1,82 +1,88 @@
 {
-    "hits": [
-      {
-        "name": "WPS Office",
-        "summary": "WPS Office Suite",
-        "keywords": null,
-        "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
-        "id": "com_wps_Office",
-        "installs_last_month": 668,
-        "app_id": "com.wps.Office",
-        "icon": "https://www.wps.com/assets/mediahub/WPS-Office-Mobile.png",
-        "categories": [
-          "Office"
-        ],
-        "developer_name": "Kingsoft Office Corporation",
-        "project_group": null,
-        "verification_verified": null,
-        "verification_method": null,
-        "verification_login_is_organization": null,
-        "verification_login_name": null,
-        "verification_login_provider": null,
-        "verification_website": null,
-        "verification_timestamp": null,
-        "updated_at": 1610973768,
-        "added_at": 1610973768
-      },
-      {
-        "name": "AnyDesk",
-        "summary": "Connect to a computer remotely",
-        "keywords": null,
-        "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
-        "id": "com_anydesk_Anydesk",
-        "installs_last_month": 613,
-        "app_id": "com.anydesk.Anydesk",
-        "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
-        "categories": [
-          "Network"
-        ],
-        "developer_name": "AnyDesk Software GmbH",
-        "project_group": null,
-        "verification_verified": null,
-        "verification_method": null,
-        "verification_login_is_organization": null,
-        "verification_login_name": null,
-        "verification_login_provider": null,
-        "verification_website": null,
-        "verification_timestamp": null,
-        "updated_at": 1610973790,
-        "added_at": 1610973790
-      },
-      {
-        "name": "Maze",
-        "summary": "A simple maze game",
-        "keywords": null,
-        "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
-        "id": "org_sugarlabs_Maze",
-        "installs_last_month": 467,
-        "app_id": "org.sugarlabs.Maze",
-        "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
-        "categories": [
-          "Game"
-        ],
-        "developer_name": "Sugar Labs Community",
-        "project_group": "SugarLabs",
-        "verification_verified": null,
-        "verification_method": null,
-        "verification_login_is_organization": null,
-        "verification_login_name": null,
-        "verification_login_provider": null,
-        "verification_website": null,
-        "verification_timestamp": null,
-        "updated_at": 1610973680,
-        "added_at": 1610973680
-      }
-    ],
-    "query": "",
-    "processingTimeMs": 0,
-    "hitsPerPage": 250,
-    "page": 1,
-    "totalPages": 1,
-    "totalHits": 3
-  }
+  "hits": [
+    {
+      "name": "WPS Office",
+      "summary": "WPS Office Suite",
+      "keywords": null,
+      "description": "WPS Office including Writer, Presentation and Spreadsheets, is a powerful office suite, which is able to process word file, produce wonderful slides, and analyze data as well. It is deeply compatible with all of the latest Microsoft Office file formats. It can easily open and read the documents created with Microsoft Office.NOTE: This wrapper is not verified by, affiliated with, or supported by Kingsoft Office Corporation",
+      "id": "com_wps_Office",
+      "installs_last_month": 668,
+      "is_free_license": false,
+      "app_id": "com.wps.Office",
+      "icon": "https://www.wps.com/assets/mediahub/WPS-Office-Mobile.png",
+      "categories": [
+        "Office"
+      ],
+      "developer_name": "Kingsoft Office Corporation",
+      "project_group": null,
+      "project_license": "LicenseRef-proprietary=http://wps-community.org/license.md",
+      "verification_verified": null,
+      "verification_method": null,
+      "verification_login_is_organization": null,
+      "verification_login_name": null,
+      "verification_login_provider": null,
+      "verification_website": null,
+      "verification_timestamp": null,
+      "updated_at": 1610973768,
+      "added_at": 1610973768
+    },
+    {
+      "name": "AnyDesk",
+      "summary": "Connect to a computer remotely",
+      "keywords": null,
+      "description": "AnyDesk ensures secure and reliable remote desktop connections for IT professionals and on-the-go individuals alike.NOTE: This wrapper is not verified by, affiliated with, or supported by AnyDesk.",
+      "id": "com_anydesk_Anydesk",
+      "installs_last_month": 613,
+      "is_free_license": false,
+      "app_id": "com.anydesk.Anydesk",
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/com.anydesk.Anydesk.png",
+      "categories": [
+        "Network"
+      ],
+      "developer_name": "AnyDesk Software GmbH",
+      "project_group": null,
+      "project_license": "LicenseRef-proprietary",
+      "verification_verified": null,
+      "verification_method": null,
+      "verification_login_is_organization": null,
+      "verification_login_name": null,
+      "verification_login_provider": null,
+      "verification_website": null,
+      "verification_timestamp": null,
+      "updated_at": 1610973790,
+      "added_at": 1610973790
+    },
+    {
+      "name": "Maze",
+      "summary": "A simple maze game",
+      "keywords": null,
+      "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
+      "id": "org_sugarlabs_Maze",
+      "installs_last_month": 467,
+      "is_free_license": true,
+      "app_id": "org.sugarlabs.Maze",
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "developer_name": "Sugar Labs Community",
+      "project_group": "SugarLabs",
+      "project_license": "GPL-3.0-or-later",
+      "verification_verified": null,
+      "verification_method": null,
+      "verification_login_is_organization": null,
+      "verification_login_name": null,
+      "verification_login_provider": null,
+      "verification_website": null,
+      "verification_timestamp": null,
+      "updated_at": 1610973680,
+      "added_at": 1610973680
+    }
+  ],
+  "query": "",
+  "processingTimeMs": 0,
+  "hitsPerPage": 250,
+  "page": 1,
+  "totalPages": 1,
+  "totalHits": 3
+}

--- a/backend/tests/results/test_search_query_by_appid.json
+++ b/backend/tests/results/test_search_query_by_appid.json
@@ -1,33 +1,35 @@
 {
-    "hits": [
-      {
-        "name": "Maze",
-        "summary": "A simple maze game",
-        "keywords": null,
-        "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
-        "id": "org_sugarlabs_Maze",
-        "installs_last_month": 467,
-        "app_id": "org.sugarlabs.Maze",
-        "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
-        "categories": [
-          "Game"
-        ],
-        "developer_name": "Sugar Labs Community",
-        "project_group": "SugarLabs",
-        "verification_verified": null,
-        "verification_method": null,
-        "verification_login_is_organization": null,
-        "verification_login_name": null,
-        "verification_login_provider": null,
-        "verification_website": null,
-        "verification_timestamp": null,
-        "updated_at": 1610973680,
-        "added_at": 1610973680
-      }
-    ],
-    "query": "Maze",
-    "processingTimeMs": 0,
-    "limit": 250,
-    "offset": 0,
-    "estimatedTotalHits": 1
-  }
+  "hits": [
+    {
+      "name": "Maze",
+      "summary": "A simple maze game",
+      "keywords": null,
+      "description": "Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.",
+      "id": "org_sugarlabs_Maze",
+      "installs_last_month": 467,
+      "is_free_license": true,
+      "app_id": "org.sugarlabs.Maze",
+      "icon": "https://dl.flathub.org/repo/appstream/x86_64/icons/128x128/org.sugarlabs.Maze.png",
+      "categories": [
+        "Game"
+      ],
+      "developer_name": "Sugar Labs Community",
+      "project_group": "SugarLabs",
+      "project_license": "GPL-3.0-or-later",
+      "verification_verified": null,
+      "verification_method": null,
+      "verification_login_is_organization": null,
+      "verification_login_name": null,
+      "verification_login_provider": null,
+      "verification_website": null,
+      "verification_timestamp": null,
+      "updated_at": 1610973680,
+      "added_at": 1610973680
+    }
+  ],
+  "query": "Maze",
+  "processingTimeMs": 0,
+  "limit": 250,
+  "offset": 0,
+  "estimatedTotalHits": 1
+}

--- a/frontend/pages/apps/search/[query].tsx
+++ b/frontend/pages/apps/search/[query].tsx
@@ -3,9 +3,65 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import { NextSeo } from "next-seo"
 import { useRouter } from "next/router"
 import Spinner from "src/components/Spinner"
-import Collection from "../../../src/components/application/Collection"
 import { useSearchQuery } from "../../../src/hooks/useSearchQuery"
 import { useLocalStorage } from "../../../src/hooks/useLocalStorage"
+import Toggle from "../../../src/components/Toggle"
+import { FunctionComponent } from "react"
+import { AppsIndex, MeilisearchResponseLimited } from "src/meilisearch"
+import ApplicationCard from "src/components/application/ApplicationCard"
+
+interface Props {
+  results: MeilisearchResponseLimited<AppsIndex>
+}
+
+const SearchResults: FunctionComponent<Props> = ({ results }) => {
+  const { t } = useTranslation()
+
+  if (!results) {
+    return <Spinner size="l" />
+  }
+
+  if (!results || results.estimatedTotalHits === 0) {
+    return (
+      <>
+        <p>{t("could-not-find-match-for-search")}</p>
+        <p>
+          <Trans i18nKey={"common:request-new-app"}>
+            If you&apos;re searching for a specific application, let the
+            community know, that you want it on flathub
+            <a
+              target="_blank"
+              rel="noreferrer"
+              className="no-underline hover:underline"
+              href="https://discourse.flathub.org/t/about-the-requests-category/22"
+            >
+              here
+            </a>
+            .
+          </Trans>
+        </p>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <p>
+        {t("number-of-results", {
+          number: results.estimatedTotalHits,
+        })}
+      </p>
+
+      <div className="grid grid-cols-1 justify-around gap-4 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-3">
+        {results.hits.map((app) => (
+          <div key={app.id} className={"flex flex-col gap-2"}>
+            <ApplicationCard application={app} />
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}
 
 export default function Search() {
   const { t } = useTranslation()
@@ -28,38 +84,19 @@ export default function Search() {
       />
 
       <div className="max-w-11/12 mx-auto my-0 mt-6 w-11/12 2xl:w-[1400px] 2xl:max-w-[1400px]">
-        {!searchResult && <Spinner size="l" />}
-        {searchResult && searchResult.length > 0 && (
-          <Collection
-            title={t("search-for-query", { query })}
-            applications={searchResult}
-            freeSoftwareOnly={freeSoftwareOnly}
-            setFreeSoftwareOnly={setFreeSoftwareOnly}
-          />
-        )}
-        {searchResult && searchResult.length === 0 && (
-          <>
-            <h2 className="mb-6 mt-12 text-2xl font-bold">
-              {t("search-for-query", { query })}
-            </h2>
-            <p>{t("could-not-find-match-for-search")}</p>
-            <p>
-              <Trans i18nKey={"common:request-new-app"}>
-                If you&apos;re searching for a specific application, let the
-                community know, that you want it on flathub
-                <a
-                  target="_blank"
-                  rel="noreferrer"
-                  className="no-underline hover:underline"
-                  href="https://discourse.flathub.org/t/about-the-requests-category/22"
-                >
-                  here
-                </a>
-                .
-              </Trans>
-            </p>
-          </>
-        )}
+        <span className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">
+            {t("search-for-query", { query })}
+          </h1>
+          <div className="flex gap-3">
+            <label>{t("free-software-only")}</label>
+            <Toggle
+              enabled={freeSoftwareOnly}
+              setEnabled={setFreeSoftwareOnly}
+            />
+          </div>
+        </span>
+        <SearchResults results={searchResult} />
       </div>
     </>
   )

--- a/frontend/pages/apps/search/[query].tsx
+++ b/frontend/pages/apps/search/[query].tsx
@@ -5,13 +5,18 @@ import { useRouter } from "next/router"
 import Spinner from "src/components/Spinner"
 import Collection from "../../../src/components/application/Collection"
 import { useSearchQuery } from "../../../src/hooks/useSearchQuery"
+import { useLocalStorage } from "../../../src/hooks/useLocalStorage"
 
 export default function Search() {
   const { t } = useTranslation()
   const router = useRouter()
   const { query } = router.query
+  const [freeSoftwareOnly, setFreeSoftwareOnly] = useLocalStorage(
+    "search-free-software-only",
+    false,
+  )
 
-  const searchResult = useSearchQuery(query as string)
+  const searchResult = useSearchQuery(query as string, freeSoftwareOnly)
 
   return (
     <>
@@ -28,6 +33,8 @@ export default function Search() {
           <Collection
             title={t("search-for-query", { query })}
             applications={searchResult}
+            freeSoftwareOnly={freeSoftwareOnly}
+            setFreeSoftwareOnly={setFreeSoftwareOnly}
           />
         )}
         {searchResult && searchResult.length === 0 && (

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -293,5 +293,6 @@
   "explore-apps": "Explore apps",
   "setup-flathub": "Setup Flathub",
   "setup-flathub-description": "Setup Flathub to install and update apps on your system.",
-  "tags-colon": "Tags:"
+  "tags-colon": "Tags:",
+  "free-software-only": "Only show Free Software"
 }

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -9,7 +9,6 @@ import Button from "../Button"
 import ButtonLink from "../ButtonLink"
 import Pagination from "../Pagination"
 import ApplicationCard from "./ApplicationCard"
-import Toggle from "../Toggle"
 
 interface Props {
   applications: Appstream[] | AppstreamListItem[]
@@ -20,8 +19,6 @@ interface Props {
   totalPages?: number
   totalHits?: number
   onRefresh?: () => void
-  freeSoftwareOnly?: boolean
-  setFreeSoftwareOnly?: (arg0: boolean) => void
 }
 
 const ApplicationCollection: FunctionComponent<Props> = ({
@@ -33,8 +30,6 @@ const ApplicationCollection: FunctionComponent<Props> = ({
   totalPages,
   totalHits,
   onRefresh,
-  freeSoftwareOnly,
-  setFreeSoftwareOnly,
 }) => {
   const { t } = useTranslation()
   const router = useRouter()
@@ -47,12 +42,6 @@ const ApplicationCollection: FunctionComponent<Props> = ({
     <span className="flex items-center justify-between">
       <h2 className="text-2xl font-bold">{title}</h2>
       {refresh}
-      {freeSoftwareOnly !== undefined && setFreeSoftwareOnly && (
-        <div className="flex gap-3">
-          <label>{t("free-software-only")}</label>
-          <Toggle enabled={freeSoftwareOnly} setEnabled={setFreeSoftwareOnly} />
-        </div>
-      )}
     </span>
   )
 

--- a/frontend/src/components/application/Collection.tsx
+++ b/frontend/src/components/application/Collection.tsx
@@ -9,6 +9,7 @@ import Button from "../Button"
 import ButtonLink from "../ButtonLink"
 import Pagination from "../Pagination"
 import ApplicationCard from "./ApplicationCard"
+import Toggle from "../Toggle"
 
 interface Props {
   applications: Appstream[] | AppstreamListItem[]
@@ -19,6 +20,8 @@ interface Props {
   totalPages?: number
   totalHits?: number
   onRefresh?: () => void
+  freeSoftwareOnly?: boolean
+  setFreeSoftwareOnly?: (arg0: boolean) => void
 }
 
 const ApplicationCollection: FunctionComponent<Props> = ({
@@ -30,6 +33,8 @@ const ApplicationCollection: FunctionComponent<Props> = ({
   totalPages,
   totalHits,
   onRefresh,
+  freeSoftwareOnly,
+  setFreeSoftwareOnly,
 }) => {
   const { t } = useTranslation()
   const router = useRouter()
@@ -42,6 +47,12 @@ const ApplicationCollection: FunctionComponent<Props> = ({
     <span className="flex items-center justify-between">
       <h2 className="text-2xl font-bold">{title}</h2>
       {refresh}
+      {freeSoftwareOnly !== undefined && setFreeSoftwareOnly && (
+        <div className="flex gap-3">
+          <label>{t("free-software-only")}</label>
+          <Toggle enabled={freeSoftwareOnly} setEnabled={setFreeSoftwareOnly} />
+        </div>
+      )}
     </span>
   )
 

--- a/frontend/src/env.ts
+++ b/frontend/src/env.ts
@@ -10,8 +10,13 @@ export const SUMMARY_DETAILS = (id: string): string =>
   `${BASE_URI}/summary/${id}`
 export const STATS_DETAILS = (id: string): string => `${BASE_URI}/stats/${id}`
 export const STATS = `${BASE_URI}/stats`
-export const SEARCH_APP = (query: string): string =>
-  `${BASE_URI}/search/${encodeURIComponent(query)}`
+export const SEARCH_APP = (
+  query: string,
+  free_software_only: boolean,
+): string =>
+  `${BASE_URI}/search/${encodeURIComponent(
+    query,
+  )}?free_software_only=${free_software_only}`
 export const POPULAR_LAST_MONTH_URL = (
   page?: number,
   per_page?: number,

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -264,9 +264,12 @@ export async function fetchProjectgroupApps(
   return appList
 }
 
-export async function fetchSearchQuery(query: string) {
+export async function fetchSearchQuery(
+  query: string,
+  freeSoftwareOnly: boolean,
+) {
   const queryEncoded = encodeURIComponent(query).replace(/\./g, "%2E")
-  const appListRes = await fetch(SEARCH_APP(queryEncoded))
+  const appListRes = await fetch(SEARCH_APP(queryEncoded, freeSoftwareOnly))
   const appList: MeilisearchResponse<AppsIndex> = await appListRes.json()
 
   console.log(`Search for query: ${queryEncoded} fetched`)

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -33,7 +33,11 @@ import { Stats } from "./types/Stats"
 import { VendingConfig } from "./types/Vending"
 import { VerificationStatus } from "./types/VerificationStatus"
 import { VerificationAvailableMethods } from "./types/VerificationAvailableMethods"
-import { AppsIndex, MeilisearchResponse } from "./meilisearch"
+import {
+  AppsIndex,
+  MeilisearchResponse,
+  MeilisearchResponseLimited,
+} from "./meilisearch"
 
 export async function fetchAppstreamList(): Promise<string[]> {
   let entryJson: string[]
@@ -270,9 +274,11 @@ export async function fetchSearchQuery(
 ) {
   const queryEncoded = encodeURIComponent(query).replace(/\./g, "%2E")
   const appListRes = await fetch(SEARCH_APP(queryEncoded, freeSoftwareOnly))
-  const appList: MeilisearchResponse<AppsIndex> = await appListRes.json()
+  const appList: MeilisearchResponseLimited<AppsIndex> = await appListRes.json()
 
-  console.log(`Search for query: ${queryEncoded} fetched`)
+  console.log(
+    `Search for query: ${queryEncoded} and freeSoftwareOnly: ${freeSoftwareOnly} fetched`,
+  )
 
   return appList
 }

--- a/frontend/src/hooks/useSearchQuery.ts
+++ b/frontend/src/hooks/useSearchQuery.ts
@@ -2,22 +2,20 @@ import { useMatomo } from "@jonkoops/matomo-tracker-react"
 import { useState, useEffect } from "react"
 
 import { fetchSearchQuery } from "../fetchers"
-import { AppstreamListItem } from "../types/Appstream"
-import { mapAppsIndexToAppstreamListItem } from "src/meilisearch"
+import { AppsIndex, MeilisearchResponseLimited } from "src/meilisearch"
 
 export function useSearchQuery(
   query: string,
   freeSoftwareOnly: boolean,
-): AppstreamListItem[] {
+): MeilisearchResponseLimited<AppsIndex> {
   const { trackSiteSearch } = useMatomo()
-  const [searchResult, setSearchResult] = useState<AppstreamListItem[] | null>(
-    null,
-  )
+  const [searchResult, setSearchResult] =
+    useState<MeilisearchResponseLimited<AppsIndex> | null>(null)
 
   useEffect(() => {
     const callSearch = async () => {
       const applications = await fetchSearchQuery(query, freeSoftwareOnly)
-      setSearchResult(applications.hits.map(mapAppsIndexToAppstreamListItem))
+      setSearchResult(applications)
       trackSiteSearch({
         keyword: query as string,
         count: applications.hits.length,

--- a/frontend/src/hooks/useSearchQuery.ts
+++ b/frontend/src/hooks/useSearchQuery.ts
@@ -5,7 +5,10 @@ import { fetchSearchQuery } from "../fetchers"
 import { AppstreamListItem } from "../types/Appstream"
 import { mapAppsIndexToAppstreamListItem } from "src/meilisearch"
 
-export function useSearchQuery(query: string): AppstreamListItem[] {
+export function useSearchQuery(
+  query: string,
+  freeSoftwareOnly: boolean,
+): AppstreamListItem[] {
   const { trackSiteSearch } = useMatomo()
   const [searchResult, setSearchResult] = useState<AppstreamListItem[] | null>(
     null,
@@ -13,7 +16,7 @@ export function useSearchQuery(query: string): AppstreamListItem[] {
 
   useEffect(() => {
     const callSearch = async () => {
-      const applications = await fetchSearchQuery(query)
+      const applications = await fetchSearchQuery(query, freeSoftwareOnly)
       setSearchResult(applications.hits.map(mapAppsIndexToAppstreamListItem))
       trackSiteSearch({
         keyword: query as string,
@@ -25,7 +28,7 @@ export function useSearchQuery(query: string): AppstreamListItem[] {
       setSearchResult(null)
       callSearch()
     }
-  }, [trackSiteSearch, query])
+  }, [trackSiteSearch, query, freeSoftwareOnly])
 
   return searchResult
 }

--- a/frontend/src/meilisearch.ts
+++ b/frontend/src/meilisearch.ts
@@ -10,6 +10,20 @@ export interface MeilisearchResponse<T> {
   totalHits: number
 }
 
+export interface MeilisearchResponseLimited<T> {
+  hits: T[]
+  query: string
+  processingTimeMs: number
+  limit: number
+  offset: number
+  estimatedTotalHits: number
+  facetDistribution: {
+    [key: string]: {
+      [key: string]: number
+    }
+  }
+}
+
 export interface AppsIndex {
   /// Be careful, this is not the same as the flatpak app id use the app_id field instead
   id: string


### PR DESCRIPTION
Decided to have a go at the first part of #1365, too :slightly_smiling_face: wasn't as difficult as I anticipated

This PR adds:
- `is_free_license` and `project_license` to the apps index of Meilisearch. `is_free_license` to speed up filtering ad the index can be precomputed and no string comparison is needed when the actual search is happening. `project_license` because I thought it's a useful field to have in general.
- Ability to the `/search` endpoint to filter for Free Software only. I left the default behavior at "including proprietary software" because I think that's what most people use Flathub for, getting their Spotifys, Google Chromes and Microsoft Teams in a safe way without messing up their system with half-hearted Linux packages from proprietary vendors. Edit: Not trying to imply here that's all Flathub is good for — in fact I prefer to have all my GUI apps be installed via Flatpak — just saying I have the impression it's most popular for proprietary software.
- A toggle to the search page to toggle whether to show Free Software only or not. The preference is saved to local storage for persistence. Again, I set the default to false because see bullet above. Other pages and collections are unaffected by this.