### PR TITLE
Expose keywords as tags on app pages

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -290,5 +290,6 @@
   "browse": "Browse",
   "explore-apps": "Explore apps",
   "setup-flathub": "Setup Flathub",
-  "setup-flathub-description": "Setup Flathub to install and update apps on your system."
+  "setup-flathub-description": "Setup Flathub to install and update apps on your system.",
+  "tags-colon": "Tags:"
 }

--- a/frontend/src/components/application/Badge.tsx
+++ b/frontend/src/components/application/Badge.tsx
@@ -1,0 +1,15 @@
+import { FunctionComponent } from "react"
+
+interface Props {
+  text: string
+}
+
+const Tags: FunctionComponent<Props> = ({ text }) => {
+  return (
+    <span className="inline-flex items-center rounded-full bg-flathub-gainsborow px-1.5 py-0.5 text-xs font-medium text-flathub-sonic-silver dark:bg-flathub-arsenic dark:text-flathub-spanish-gray">
+      {text}
+    </span>
+  )
+}
+
+export default Tags

--- a/frontend/src/components/application/Details.tsx
+++ b/frontend/src/components/application/Details.tsx
@@ -44,6 +44,7 @@ import {
   MeilisearchResponse,
   mapAppsIndexToAppstreamListItem,
 } from "src/meilisearch"
+import Tags from "./Tags"
 
 interface Props {
   app?: Appstream
@@ -315,6 +316,8 @@ const Details: FunctionComponent<Props> = ({
           <AppStatistics stats={stats}></AppStatistics>
 
           <CmdInstructions appId={app.id}></CmdInstructions>
+
+          <Tags keywords={app.keywords} />
         </div>
       </div>
     )

--- a/frontend/src/components/application/Tags.tsx
+++ b/frontend/src/components/application/Tags.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from "next-i18next"
+import { FunctionComponent } from "react"
+import Badge from "./Badge"
+import Link from "next/link"
+
+interface Props {
+  keywords: string[]
+}
+
+const Tags: FunctionComponent<Props> = ({ keywords }) => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      {keywords && (
+        <div className="flex gap-2 text-sm">
+          <div>{t("tags-colon")}</div>
+          <div className="flex flex-wrap gap-2">
+            {keywords &&
+              keywords.map((item, index) => {
+                return (
+                  <Link key={index} href={`/apps/search/${item}`}>
+                    <Badge text={item} />
+                  </Link>
+                )
+              })}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default Tags

--- a/frontend/src/types/Appstream.ts
+++ b/frontend/src/types/Appstream.ts
@@ -23,6 +23,7 @@ export interface Appstream {
   launchable: Launchable
   bundle: Bundle
   metadata?: Metadata
+  keywords: string[]
 }
 
 interface ContentRating {


### PR DESCRIPTION
Showing these on the app page, should lead to search engines picking these up. And hopefully improving how apps get found from those.