### PR TITLE
feat: error boundary closes #456

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -17,6 +17,9 @@ import { bcpToPosixLocale, languages } from "../src/localize"
 import Main from "../src/components/layout/Main"
 
 import { Inter } from "next/font/google"
+import * as Sentry from "@sentry/react"
+import { Error } from "../src/components/Error"
+
 const inter = Inter({
   subsets: ["latin"],
 })
@@ -71,4 +74,6 @@ const App = ({ Component, pageProps }: AppProps) => {
   )
 }
 
-export default appWithTranslation(App)
+export default Sentry.withErrorBoundary(appWithTranslation(App), {
+  fallback: <Error />,
+})

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -294,5 +294,6 @@
   "setup-flathub": "Setup Flathub",
   "setup-flathub-description": "Setup Flathub to install and update apps on your system.",
   "tags-colon": "Tags:",
-  "free-software-only": "Only show Free Software"
+  "free-software-only": "Only show Free Software",
+  "something-went-wrong": "Something went wrong"
 }

--- a/frontend/src/components/Error.tsx
+++ b/frontend/src/components/Error.tsx
@@ -1,0 +1,24 @@
+import { Trans, useTranslation } from "next-i18next"
+import { NextSeo } from "next-seo"
+
+export const Error = () => {
+  const { t } = useTranslation()
+  return (
+    <>
+      <NextSeo title={t("something-went-wrong")} />
+      <div className="max-w-11/12 mx-auto my-0 w-11/12 2xl:w-[1400px] 2xl:max-w-[1400px]">
+        <h1 className="my-8">{t("whoops")}</h1>
+        <p>{t("something-went-wrong")}</p>
+        <p>
+          <Trans i18nKey={"common:retry-or-go-home"}>
+            You might want to retry or go back{" "}
+            <a className="no-underline hover:underline" href=".">
+              home
+            </a>
+            .
+          </Trans>
+        </p>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
Right now I am displaying `Custom404` component if  I could get UI for custom error I can easily change it

closes #456