### PR TITLE
Widen sentry upload

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -152,6 +152,7 @@ const sentryExports = (phase) => {
       // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
       // for more information.
       hideSourceMaps: true,
+      widenClientFileUpload: true,
     },
   }
 }


### PR DESCRIPTION
According to docs should help with missing source maps. See https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#widen-the-upload-scope