### PR TITLE
Guard avatar against empty username

### DIFF
--- a/frontend/src/components/user/Avatar.tsx
+++ b/frontend/src/components/user/Avatar.tsx
@@ -12,8 +12,13 @@ const celestialBlue = "#4a90d9"
 const variationTone = "#70dee6"
 
 const Avatar: FunctionComponent<Props> = (props: Props) => {
-  const { avatarUrl, userName } = props
   const { t } = useTranslation()
+
+  if (!props.userName) {
+    return null
+  }
+
+  const { avatarUrl, userName } = props
 
   return avatarUrl ? (
     <Image


### PR DESCRIPTION
This might be possible when logging in? At least it's in the sentry logs.

Fixes https://flathub.sentry.io/issues/4164687333/events/2ac0c774fb224073be6aac66cb77c393/