### PR TITLE
Move screenshots to front

### DIFF
--- a/frontend/pages/apps/[appDetails].tsx
+++ b/frontend/pages/apps/[appDetails].tsx
@@ -55,10 +55,10 @@ export default function Details({
         openGraph={{
           url: `${process.env.NEXT_PUBLIC_SITE_BASE_URI}/apps/${app?.id}`,
           images: [
+            ...screenshots,
             {
               url: app?.icon,
             },
-            ...screenshots,
           ],
         }}
       />


### PR DESCRIPTION
Element and mastodon seem to not be smart about the images and end up
 showing the icon is cases, where a bigger screenshot would be nicer.

 This should lead to screenshots showing in social medai posts
 instead of the icon.