### PR TITLE
Use flex for subcategories

### DIFF
--- a/frontend/pages/apps/category/[category]/[page].tsx
+++ b/frontend/pages/apps/category/[category]/[page].tsx
@@ -55,7 +55,7 @@ const ApplicationCategory = ({
 
         {subcategories && (
           <div>
-            <div className="grid grid-cols-[repeat(auto-fill,_minmax(125px,_1fr))] gap-2">
+            <div className="flex flex-wrap gap-2">
               {getSubcategory(category).map((subcategory) => (
                 <Link
                   key={subcategory}


### PR DESCRIPTION
Makes subcategories section look more compact and prevents occasional text wrapping
![изображение](https://github.com/flathub/website/assets/71165491/6774a23e-a4af-4f5c-8db7-618a43ee2d7e)
![изображение](https://github.com/flathub/website/assets/71165491/fd46bb95-9eee-4e8f-a2b2-09ef604da5e5)
