### PR TITLE
Don't show localized Screenshots

### DIFF
--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -89,7 +89,7 @@ def appstream2dict(reponame: str):
                 attrs = {}
 
                 for image in screenshot:
-                    if image.attrib.get("type") == "thumbnail":
+                    if image.attrib.get("type") == "thumbnail" and image.attrib.get("{http://www.w3.org/XML/1998/namespace}lang") is None:
                         width = image.attrib.get("width")
                         height = image.attrib.get("height")
                         attrs[f"{width}x{height}"] = image.text


### PR DESCRIPTION
Localized  are possible since the libappstream port. I already use it in [one of my Apps](https://flathub.org/apps/page.codeberg.JakobDev.jdReplace), which confuses the Frontend. As translated AppStream Data is not wanted on the Website, this PR hides localized Screenshots.