### PR TITLE
index.tsx: add line break to "search element not found" page

### DIFF
--- a/frontend/pages/apps/search/index.tsx
+++ b/frontend/pages/apps/search/index.tsx
@@ -311,7 +311,7 @@ const SearchPanel = ({
           <h1 className="text-2xl font-bold">
             {t("search-for-query", { query })}
           </h1>
-        </span><br>
+        </span><br />
         <p>{t("could-not-find-match-for-search")}</p>
         <p>
           <Trans i18nKey={"common:request-new-app"}>

--- a/frontend/pages/apps/search/index.tsx
+++ b/frontend/pages/apps/search/index.tsx
@@ -311,7 +311,7 @@ const SearchPanel = ({
           <h1 className="text-2xl font-bold">
             {t("search-for-query", { query })}
           </h1>
-        </span>
+        </span><br>
         <p>{t("could-not-find-match-for-search")}</p>
         <p>
           <Trans i18nKey={"common:request-new-app"}>


### PR DESCRIPTION
## Context

Currently, when I search for an application which isn't present the below text is displayed

![image](https://github.com/flathub/website/assets/26346867/63151077-1e0f-4579-99aa-1d18df41d560)

The "Could not find a match for search." text is placed close to the heading, making it look cramped in some translations and small device form factors.

![image](https://github.com/flathub/website/assets/26346867/a4bc026d-b8ae-4be4-8a12-102960b8d1d3)

## Change

This PR adds a line break to give space between the heading and subsequent text.

![image](https://github.com/flathub/website/assets/26346867/9a2838da-548a-447d-9dc0-001e4175d696)

![image](https://github.com/flathub/website/assets/26346867/eda627c7-a832-4c43-8952-2c116977c1cd)

