### PR TITLE
Allow other app types in the backend

### DIFF
--- a/backend/app/apps.py
+++ b/backend/app/apps.py
@@ -103,6 +103,7 @@ def load_appstream():
                 p.sadd("types:index", type)
                 p.sadd(f"types:{type}", redis_key)
 
+            # only used for compat
             if categories := apps[appid].get("categories"):
                 for category in categories:
                     p.sadd(f"categories:{category}", redis_key)
@@ -139,6 +140,7 @@ def list_desktop_appstream():
     return sorted(list(apps_desktop | apps_desktop_application))
 
 
+# Only used for compat
 def get_recently_updated(limit: int = 100):
     zset = db.redis_conn.zrevrange("recently_updated_zset", 0, limit - 1)
     return [
@@ -149,6 +151,7 @@ def get_recently_updated(limit: int = 100):
     ]
 
 
+# Only used for compat
 def get_recently_added(limit: int = 100):
     zset = db.redis_conn.zrevrange("new_apps_zset", 0, limit - 1)
     return [

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -3,7 +3,7 @@ import time
 import orjson
 import redis
 
-from . import config, schemas
+from . import config
 
 redis_conn = redis.Redis(
     db=config.settings.redis_db,
@@ -38,10 +38,6 @@ def get_json_key(key: str):
         return orjson.loads(value)
 
     return None
-
-
-def get_category_count(category: schemas.MainCategory):
-    return redis_conn.scard(f"categories:{category.value}")
 
 
 def get_developers():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -204,7 +204,7 @@ def get_project_group(
 
 @app.get("/appstream")
 def list_appstream():
-    return apps.list_appstream()
+    return apps.list_desktop_appstream()
 
 
 @app.get("/appstream/{appid}", status_code=200)

--- a/backend/app/stats.py
+++ b/backend/app/stats.py
@@ -8,7 +8,7 @@ import requests
 
 from app import utils
 
-from . import config, db, schemas, search
+from . import config, db, search
 
 StatsType = dict[str, dict[str, list[int]]]
 POPULAR_DAYS_NUM = 7
@@ -100,7 +100,6 @@ def _get_stats(app_count: int) -> dict[str, dict[str, int]]:
     delta_downloads_per_day: dict[str, int] = {}
     updates_per_day: dict[str, int] = {}
     totals_country: dict[str, int] = {}
-    category_totals: dict[str, int] = {}
     with requests.Session() as session:
         for i in range((edate - sdate).days + 1):
             date = sdate + datetime.timedelta(days=i)
@@ -137,8 +136,7 @@ def _get_stats(app_count: int) -> dict[str, dict[str, int]]:
                         totals_country[country] = 0
                     totals_country[country] = totals_country[country] + downloads
 
-    for category in schemas.MainCategory:
-        category_totals[category.value] = db.get_category_count(category)
+    totals = search.search_apps_post(search.SearchQuery(query="", filters=None))
 
     return {
         "countries": totals_country,
@@ -147,7 +145,7 @@ def _get_stats(app_count: int) -> dict[str, dict[str, int]]:
         "delta_downloads_per_day": delta_downloads_per_day,
         "downloads": sum(downloads_per_day.values()),
         "number_of_apps": app_count,
-        "category_totals": category_totals,
+        "category_totals": totals["facetDistribution"]["main_categories"],
     }
 
 

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -66,9 +66,7 @@ def appstream2dict(reponame: str):
     for component in root:
         app = {}
 
-        app_type = component.attrib.get("type")
-
-        app["type"] = app_type
+        app["type"] = component.attrib.get("type")
 
         descriptions = component.findall("description")
         if len(descriptions):

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -66,8 +66,9 @@ def appstream2dict(reponame: str):
     for component in root:
         app = {}
 
-        if component.attrib.get("type") not in ("desktop", "desktop-application"):
-            continue
+        app_type = component.attrib.get("type")
+
+        app["type"] = app_type
 
         descriptions = component.findall("description")
         if len(descriptions):

--- a/backend/tests/main.py
+++ b/backend/tests/main.py
@@ -325,16 +325,9 @@ def test_stats(client):
     three_days_ago = today - datetime.timedelta(days=3)
     expected = {
         "category_totals": {
-            "AudioVideo": 0,
-            "Development": 0,
-            "Education": 0,
             "Game": 1,
-            "Graphics": 0,
             "Network": 1,
             "Office": 1,
-            "Science": 0,
-            "System": 0,
-            "Utility": 0,
         },
         "countries": {"AD": 45, "BR": 67},
         "downloads_per_day": {},

--- a/backend/tests/results/test_appstream_by_appid.json
+++ b/backend/tests/results/test_appstream_by_appid.json
@@ -1,4 +1,5 @@
 {
+  "type": "desktop",
   "description": "<p>Good at finding your way out of hard situations? Let's see! Try to make your way through an increasingly difficult path.</p>",
   "screenshots": [
     {


### PR DESCRIPTION
So that they can be managed, by people with access to them. You can also view them on the website,
 but nothing should link to them right now.