### PR TITLE
Send notifications for builds with errors or warnings

### DIFF
--- a/backend/app/email_templates/_build_diagnostic.html
+++ b/backend/app/email_templates/_build_diagnostic.html
@@ -1,0 +1,132 @@
+{% macro build_diagnostic(diagnostic) %}
+  <h3 style="margin-bottom: 0">{{ diagnostic.category }}</h3>
+
+  {% if diagnostic.refstring %}
+    {{ diagnostic.refstring }}
+  {% endif %}
+
+  <div style="margin-left: 1em">
+    {% if diagnostic.category == "failed_to_load_appstream" %}
+      <p>
+        The appstream file at {{ diagnostic.data.path }} could not be loaded. Make sure it exists, is not corrupted,
+        and the app ID is correct.
+      </p>
+      <p>
+        Error: {{ diagnostic.data.error }}
+      </p>
+    {% elif diagnostic.category == "appstream_validation" %}
+      <p>
+        The appstream file at <code>{{ diagnostic.data.path }}</code> contains errors.
+      </p>
+      {% if diagnostic.data.stdout %}
+        <h4>stdout</h4>
+        <pre>{{ diagnostic.data.stdout }}</pre>
+      {% endif %}
+      {% if diagnostic.data.stderr %}
+        <h4>stderr</h4>
+        <pre>{{ diagnostic.data.stderr }}</pre>
+      {% endif %}
+    {% elif diagnostic.category == "missing_icon" %}
+      <p>
+        The appstream file at <code>{{ diagnostic.data.appstream_path }}</code> does not contain an icon.
+      </p>
+    {% elif diagnostic.category == "no_local_icon" %}
+      <p>
+        The appstream file at <code>{{ diagnostic.data.appstream_path }}</code> only contains a remote icon for the app, not a
+        local one.
+      </p>
+    {% elif diagnostic.category == "missing_build_log_url" %}
+      <p>
+        For FOSS apps, Flathub requires that direct uploads provide a link to public build logs for each build. The build log may be
+        specified using <code>flat-manager-client</code>'s <code>--build-log-url</code> option at either the <code>create</code>
+        or <code>push</code> step.
+      </p>
+    {% elif diagnostic.category == "screenshot_not_mirrored" %}
+      <p>
+        The following screenshots in the appstream catalog file (at <code>{{ diagnostic.data.path }}</code>) are not
+        mirrored to the screenshots branch:
+      </p>
+
+      <ul>
+        {% for screenshot in diagnostic.data.urls %}
+          <li>{{ screenshot }}</li>
+        {% endfor %}
+      </ul>
+    {% elif diagnostic.category == "mirrored_screenshot_not_found" %}
+      <p>
+        The screenshots in the appstream catalog file (at <code>{{ diagnostic.data.path }}</code>) have been edited to
+        point to the Flathub mirror, but the following screenshots are not present in the <code>{{ diagnostic.data.expected_branch }}</code>
+        branch:
+      </p>
+      <ul>
+        {% for screenshot in diagnostic.data.urls %}
+          <li>{{ screenshot }}</li>
+        {% endfor %}
+      </ul>
+    {% elif diagnostic.category == "no_screenshot_branch" %}
+      <p>
+        The screenshots in the appstream file have not been mirrored to the <code>{{diagnostic.data.expected_branch}}</code>
+        OSTree branch, which is required for Flathub to display them correctly.
+      </p>
+      <p>
+        To prepare screenshots for mirroring, pass the <code>--mirror-screenshots-url=https://dl.flathub.org/media</code>
+        option to <code>flatpak-builder</code>. This option downloads screenshots from their source and saves them
+        to the build directory. Then, commit the screenshots to the <code>screenshots/&lt;architecture&gt;</code>
+        branch for each architecture.
+      </p>
+    {% elif diagnostic.category == "unexpected_files_in_screenshot_branch" %}
+      <p>
+        The following files do not match the expected app ID:
+      </p>
+
+      <ul>
+        {% for file in diagnostic.data.files %}
+          <li>{{ file }}</li>
+        {% endfor %}
+      </ul>
+
+      <p>
+        Screenshot files should be in a directory named after the app ID and branch, e.g. <code>{{ app_id }}-master</code>.
+      </p>
+    {% elif diagnostic.category == "wrong_arch_executables" %}
+      <p>
+        The following executable or shared library files are built for a different architecture than the
+        {{ diagnostic.data.expected_arch }} ref:
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Path</th>
+            <th>Detected Architecture</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for file in diagnostic.data.executables %}
+            <tr>
+              <td>
+                <code>{{ file.path }}</code>
+              </td>
+              <td>
+                {{ file.detected_arch }} ({{ file.detected_arch_code }})
+              </td>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <p>
+        This is probably a mistake. If you are including pre-built binaries in your build, make sure to use the
+        correct binaries for each architecture.
+      </p>
+    {% else %}
+      <table>
+        {% for field in diagnostic.data %}
+          <tr>
+            <td>{{ field }}</td>
+            <td>{{ diagnostic.data[field] }}</td>
+          </tr>
+        {% endfor %}
+      </table>
+    {% endif %}
+  </div>
+{% endmacro %}

--- a/backend/app/email_templates/app_name_and_id.html
+++ b/backend/app/email_templates/app_name_and_id.html
@@ -1,5 +1,1 @@
-{% if app_name %}
-  {{ app_name }} ({{ app_id }})
-{% else %}
-  {{ app_id }}
-{% endif %}
+{% if app_name %}{{ app_name }} ({{ app_id }}){% else %}{{ app_id }}{% endif %}

--- a/backend/app/email_templates/build_notification.html
+++ b/backend/app/email_templates/build_notification.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% from "_build_diagnostic.html" import build_diagnostic %}
+
+{% block content %}
+
+<span>
+  {% if any_errors %}
+    Errors were detected during validation of build #{{build_id}} ({{build_repo}}) for {% include "app_name_and_id.html" %}. This build
+    may not be published. Please address the issues and upload a new build.
+  {% else %}
+    Warnings were detected during validation of build #{{build_id}} for {% include "app_name_and_id.html" %}.
+  {% endif %}
+</span>
+
+{% if any_errors %}
+  <h2>Errors</h2>
+  {% for diagnostic in diagnostics %}
+    {% if not diagnostic.is_warning %}
+      {{ build_diagnostic(diagnostic) }}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+{% if any_warnings %}
+  <h2>Warnings</h2>
+  {% for diagnostic in diagnostics %}
+    {% if diagnostic.is_warning %}
+      {{ build_diagnostic(diagnostic) }}
+    {% endif %}
+  {% endfor %}
+{% endif %}
+
+{% endblock content %}

--- a/backend/app/email_templates/preview_data.json
+++ b/backend/app/email_templates/preview_data.json
@@ -1,0 +1,129 @@
+{
+  "security_login": {
+    "category": "security_login",
+    "data": {
+      "provider": "github",
+      "login": "testuser"
+    }
+  },
+  "moderation_held": {
+    "category": "moderation_held",
+    "data": {
+      "build_id": 123,
+      "job_id": 456,
+      "requests": [
+        {
+          "request_type": "appdata",
+          "request_data": {
+            "keys": {
+              "name": "My Awesome Test App"
+            },
+            "current_values": {
+              "name": "Test App"
+            }
+          },
+          "is_new_submission": false
+        }
+      ]
+    }
+  },
+  "moderation_approved": {
+    "category": "moderation_approved",
+    "data": {
+      "build_id": 123,
+      "job_id": 456,
+      "request": {
+        "request_type": "appdata",
+        "request_data": {
+          "keys": {
+            "name": "My Awesome Test App"
+          },
+          "current_values": {
+            "name": "Test App"
+          }
+        },
+        "is_new_submission": false
+      }
+    }
+  },
+  "moderation_rejected": {
+    "category": "moderation_rejected",
+    "data": {
+      "build_id": 123,
+      "job_id": 456,
+      "request": {
+        "request_type": "appdata",
+        "request_data": {
+          "keys": {
+            "name": "My Awesome Test App"
+          },
+          "current_values": {
+            "name": "Test App"
+          }
+        },
+        "is_new_submission": false
+      },
+      "comment": "Please use a better name for your app."
+    }
+  },
+  "build_notification": {
+    "category": "build_notification",
+    "data": {
+      "diagnostics": [
+        {
+          "refstring": "app/org.flatpak.Hello/x86_64/master",
+          "is_warning": true,
+          "category": "no_local_icon",
+          "data": {
+            "appstream_path": "files/share/appdata/org.flatpak.Hello.appdata.xml"
+          }
+        },
+        {
+          "refstring": "app/org.flatpak.Hello/x86_64/master",
+          "is_warning": false,
+          "category": "no_screenshot_branch",
+          "data": {
+            "expected_branch": "screenshots/x86_64"
+          }
+        },
+        {
+          "refstring": "app/org.flatpak.Hello/x86_64/master",
+          "is_warning": false,
+          "category": "missing_build_log_url"
+        },
+        {
+          "refstring": "app/org.gnome.Crosswords/aarch64/master",
+          "is_warning": true,
+          "category": "wrong_arch_executables",
+          "data": {
+            "expected_arch": "aarch64",
+            "executables": [
+              {
+                "path": "/files/bin/crossword-editor",
+                "detected_arch": "x86_64",
+                "detected_arch_code": 62
+              },
+              {
+                "path": "/files/bin/crosswords",
+                "detected_arch": "x86_64",
+                "detected_arch_code": 62
+              }
+            ]
+          }
+        },
+        {
+          "refstring": "screenshots/x86_64",
+          "is_warning": false,
+          "category": "unexpected_files_in_screenshot_branch",
+          "data": {
+            "files": ["screenshot.png"]
+          }
+        }
+      ],
+      "any_warnings": true,
+      "any_errors": true,
+      "build_id": 123,
+      "build_repo": "stable"
+    }
+  }
+}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from . import (
     compat,
     config,
     db,
+    emails,
     feeds,
     logins,
     moderation,
@@ -51,6 +52,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+emails.register_to_app(app)
 logins.register_to_app(app)
 moderation.register_to_app(app)
 wallet.register_to_app(app)


### PR DESCRIPTION
When a build fails validation in flat-manager-hooks, or if warnings are generated, email the developers a summary of the problems.

This only works for builds with an app ID set, since that's how we know who to send the email to.