### PR TITLE
Restore language after login

### DIFF
--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -6,12 +6,17 @@ import { useEffect } from "react"
 import LoginProviders from "../../src/components/login/Providers"
 import { useUserContext } from "../../src/context/user-info"
 import { fetchLoginProviders } from "../../src/fetchers"
-import { LoginProvider } from "../../src/types/Login"
 import { useTranslation } from "next-i18next"
 
-export default function DeveloperLoginPortal({ providers }) {
+export default function DeveloperLoginPortal({ providers, locale }) {
   const { t } = useTranslation()
   const user = useUserContext()
+
+  // Set NEXT_LOCALE cookie to match locale of this page
+  useEffect(() => {
+    if (!locale) return
+    document.cookie = `NEXT_LOCALE=${locale};path=/;SameSite=Strict`
+  }, [locale])
 
   useEffect(() => {
     // Already logged in, just redirect to userpage
@@ -43,6 +48,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     props: {
       ...(await serverSideTranslations(locale, ["common"])),
       providers,
+      locale,
     },
   }
 }


### PR DESCRIPTION
This sets a cookie on the providers page, containing the locale and restores it, after we have been redirected from the login provider.

Ideally we could send the locale to the login provider too, but that would  need changes to the redirect config, which I don't have access to.

Closes #1220