### PR TITLE
Ignore `xdg-config/kdeglobals:ro` permission

### DIFF
--- a/frontend/src/safety.ts
+++ b/frontend/src/safety.ts
@@ -361,7 +361,8 @@ function addFileSafetyRatings(summary: Summary): AppSafetyRating[] {
         x.toLowerCase() === "host:ro" ||
         x.toLowerCase() === "xdg-download" ||
         x.toLowerCase() === "xdg-download:rw" ||
-        x.toLowerCase() === "xdg-download:ro",
+        x.toLowerCase() === "xdg-download:ro" ||
+        x.toLowerCase() === "xdg-config/kdeglobals:ro",
     )
   ) {
     appSafetyRating.push({


### PR DESCRIPTION
Every App that uses a KDE Runtime has this Permission automatically, what means they all get currently a lower safety ranking