### PR TITLE
CI: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: ./backend
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v4
         with:
@@ -56,7 +56,7 @@ jobs:
         working-directory: ./backend
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/backend_deploy.yml
+++ b/.github/workflows/backend_deploy.yml
@@ -16,7 +16,7 @@ jobs:
       group: build_push_docker_backend
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -22,7 +22,7 @@ jobs:
         working-directory: ./frontend
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache
         uses: actions/cache@v3

--- a/.github/workflows/frontend_deploy.yml
+++ b/.github/workflows/frontend_deploy.yml
@@ -16,7 +16,7 @@ jobs:
       group: build_push_docker_frontend_beta
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -51,7 +51,7 @@ jobs:
       group: build_push_docker_frontend_prod
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
This PR bumps the `actions/checkout` version from `v3`(Node 16) to `v4` (Node 20) as Node 16 is reaching eol soon.
Ref. https://nodejs.org/en/blog/announcements/nodejs16-eol