### PR TITLE
fix: use sans-serif as fallback typeface

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -26,6 +26,7 @@ import { MotionConfig } from "framer-motion"
 
 const inter = Inter({
   subsets: ["latin"],
+  fallback: ["sans-serif"],
 })
 
 const App = ({ Component, pageProps }: AppProps) => {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -56,7 +56,7 @@ export default function Home({
       <NextSeo title={t("home")} description={t("flathub-description")} />
       <div className="max-w-11/12 mx-auto my-0 mt-12 w-11/12 space-y-10 2xl:w-[1400px] 2xl:max-w-[1400px]">
         <div className="flex justify-between gap-3">
-          <div className="prose dark:prose-invert">
+          <div className="prose dark:prose-invert max-w-none">
             <h1 className="mb-0 text-4xl font-extrabold">
               {t("the-linux-app-store")}
             </h1>


### PR DESCRIPTION
As a user who browses the web with downloadable fonts disabled, Flathub looks shoddy because a fallback to a generic font family wasn't included.

As Inter is a sans-serif font, `sans-serif` should be appended to the end so the browser/OS knows to grab a sans-serif font. Due to different font metrics that may arise, I also removed the `max-width` that Tailwind added so that wider typefaces don't wrap to the next line.

## Before

![image](https://github.com/flathub/website/assets/22801583/3b9aee50-97a7-417d-a439-e31f161c4695)

## After

![image](https://github.com/flathub/website/assets/22801583/447ea9d5-4101-473a-8fbb-04d950d4aaa5)