### PR TITLE
docs: migrate to docker compose v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pull requests are welcome. Please, create an issue first explaining what you wan
 
 ### Development
 
-You'll need `git`, `yarn`, `docker` and `docker-compose`.
+You'll need `git`, `yarn`, `docker` and `docker-compose-plugin`.
 
 Go to the folder where you manage your projects and checkout this project.
 
@@ -22,7 +22,7 @@ Then start the backend:
 
 ```sh
 cd backend
-docker-compose up
+docker compose up
 ```
 
 You might need to use `--build` to rebuild the images, when dependencies change.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,7 +1,7 @@
 # Flathub website backend
 
 This is the fastapi based backend for https://www.flathub.org
-Not the backend for flathub itself. Go here, if your looking for that https://github.com/flathub/flathub
+Not the backend for flathub itself. Go here, if you're looking for that https://github.com/flathub/flathub
 
 ## Development
 
@@ -15,7 +15,7 @@ Not the backend for flathub itself. Go here, if your looking for that https://gi
 Start the database:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 You need to seed the database:
@@ -76,14 +76,14 @@ Once you have made your `models.py` change:
 1. Prepare your migration with:
 
    ```bash
-   docker-compose run backend alembic revision --autogenerate -m "Title of migration"
+   docker compose run backend alembic revision --autogenerate -m "Title of migration"
    ```
 
    If the command ran successfully, a new file will be created under `alembic/versions`.
 
 2. Run the migration after the file has been created via
    ```bash
-   docker-compose run backend alembic upgrade head
+   docker compose run backend alembic upgrade head
    ```
    This will update your local database.
 
@@ -98,10 +98,10 @@ simply stop and restart the `backend` container.
 If you encounter any issues with the database and migrations, then to save yourself time and frustration it might be better to reset your Docker environment with
 
 ```bash
-docker-compose down --volumes
+docker compose down --volumes
 ```
 
-After that, using `docker-compose up` will download and give you a fresh start from the last working migration.
+After that, using `docker compose up` will download and give you a fresh start from the last working migration.
 
 After these changes, it's possible that the endpoint will need an update. To do this, open another terminal session and run
 
@@ -116,12 +116,12 @@ If there's an update in `pyproject.toml` and `poetry.lock`, this means the depen
 To do this, you run:
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
 ## Search
 
-If you running this locally, you can use http://localhost:7700/ to test the search.
+If you're running this locally, you can use http://localhost:7700/ to test the search.
 
 ## Stripe
 
@@ -176,8 +176,7 @@ If you want webhooks to make it from the testing into the backend then run:
 ### Running the website with the right keys
 
 In the backend directory you can run `env STRIPE_PUBLIC_KEY=... STRIPE_SECRET_KEY=...
-STRIPE_WEBHOOK_KEY=... docker-compose up --build`
+STRIPE_WEBHOOK_KEY=... docker compose up --build`
 
 When everything has started, if you visit <http://localhost:8000/docs> you will
 see mention of Stripe if things are working properly.
-

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -62,7 +62,7 @@ class Settings(BaseSettings):
     flat_manager_build_secret: str | None = base64.b64encode(b"secret").decode()
     # The URL for flat-manager. If present, the backend will use it to queue republish jobs when storefront info
     # changes. To test in development, set the environment variable FLAT_MANAGER_API=http://host.docker.internal:8080
-    # when running docker-compose.
+    # when running docker compose.
     flat_manager_api: str | None = None
 
     # When set to True, moderation reviews will still be logged, but they do not have to be approved for the build to


### PR DESCRIPTION
* Replaces references to Docker Compose v1 to Docker Compose v2.
* Fixes a few typos in the README.

Docker Compose v2 has been out for some time, and Docker Compose v1 (`docker-compose`) no longer receives updates.

> From July 2023 Compose V1 stopped receiving updates. It’s also no longer available in new releases of Docker Desktop.
> 
> — https://docs.docker.com/compose/ 

I think it makes sense to push the documentation and commands over to the v2 equivalents now, since this is what most engineers should have installed now.

## Related

* Similar to https://github.com/nextcloud/cookbook/pull/1772
* Similar to https://github.com/juliushaertl/nextcloud-docker-dev/pull/209