### PR TITLE
Escaping of characters isn't needed anymore

### DIFF
--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -223,11 +223,10 @@ export async function fetchSearchQuery(
     value: string
   }[],
 ) {
-  const queryEncoded = encodeURIComponent(query).replace(/\./g, "%2E")
   return axios.post<MeilisearchResponseLimited<AppsIndex>>(
     SEARCH_APP,
     {
-      query: queryEncoded,
+      query: query,
       filters: selectedFilters,
     },
     {


### PR DESCRIPTION
As this is now using the POST endpoint, we don't need to URL encode the search string anymore.

Closes #1836