### PR TITLE
Fix broken vending and transaction endpoints

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -834,7 +834,7 @@ class Transaction(Base):
         return db.session.query(Transaction).filter(Transaction.user_id == user.id)
 
     @classmethod
-    def by_user_and_id(cls, db, user: FlathubUser, txnid: str):
+    def by_user_and_id(cls, db, user: FlathubUser, txnid: str) -> "Transaction":
         return (
             db.session.query(Transaction)
             .filter(Transaction.user_id == user.id)

--- a/backend/app/vending/__init__.py
+++ b/backend/app/vending/__init__.py
@@ -337,7 +337,7 @@ def get_app_vending_setup(appid: str, login=Depends(login_state)) -> VendingSetu
 @router.post("app/{appid}/setup")
 def post_app_vending_setup(
     appid: str, setup: VendingSetup, login=Depends(login_state)
-) -> VendingDescriptor:
+) -> VendingSetup:
     """
     Create/update the vending status for a given application.  Returns an error
     if the appid is not known, or if it's already set up for vending with a

--- a/backend/app/wallet/stripewallet.py
+++ b/backend/app/wallet/stripewallet.py
@@ -264,8 +264,9 @@ class StripeWallet(WalletBase):
             if payment_method is not None:
                 payment_method = stripe.PaymentMethod.retrieve(payment_method)
                 card = self._cardinfo(payment_method)
-            if payment_intent["charges"]["total_count"] > 0:
-                receipt = payment_intent["charges"]["data"][0].get("receipt_url")
+            charges = payment_intent.get("charges")
+            if charges is not None and charges["total_count"] > 0:
+                receipt = charges["data"][0].get("receipt_url")
         except Exception as stripe_error:
             raise WalletError(error="not found") from stripe_error
 

--- a/backend/app/wallet/stripewallet.py
+++ b/backend/app/wallet/stripewallet.py
@@ -118,14 +118,14 @@ class StripeWallet(WalletBase):
 
         return [
             TransactionSummary(
-                id=txn.id,
+                id=str(txn.id),
                 value=txn.value,
                 currency=txn.currency,
                 kind=txn.kind,
                 status=txn.status,
                 reason=txn.reason,
-                created=txn.created.timestamp(),
-                updated=txn.updated.timestamp(),
+                created=int(txn.created.timestamp()),
+                updated=int(txn.updated.timestamp()),
             )
             for txn in txns
         ]
@@ -237,14 +237,14 @@ class StripeWallet(WalletBase):
             db.session.add(txn)
             db.session.commit()
         summary = TransactionSummary(
-            id=txn.id,
+            id=str(txn.id),
             value=txn.value,
             currency=txn.currency,
             kind=txn.kind,
             status=txn.status,
             reason=txn.reason,
-            created=txn.created.timestamp(),
-            updated=txn.updated.timestamp(),
+            created=int(txn.created.timestamp()),
+            updated=int(txn.updated.timestamp()),
         )
         details = [
             TransactionRow(


### PR DESCRIPTION
Ran into a few broken endpoints in the vending and payment flows.

- The `charges` key was assumed present in the Stripe payment intent object when fetching a transactions details. This seems to only appear after payment.
- Pydantic caught a bad return type from the vending setup endpoint.
- Pydantic caught bad types in the `TransactionSummary` when fetching transaction details
    - Timestamps were returning as floats and not ints
    - The primary key was not being cast from an int to a string as expected