### PR TITLE
logins: Use up to date display name

### DIFF
--- a/backend/app/logins.py
+++ b/backend/app/logins.py
@@ -954,9 +954,11 @@ def get_userinfo(login: LoginStatusDep):
         user.invite_code = "".join(secrets.choice(chars) for _ in range(12))
         db.session.commit()
 
+    default_account = user.get_default_account(db)
+
     ret = {
         "is-moderator": user.is_moderator,
-        "displayname": user.display_name,
+        "displayname": default_account.display_name,
         "dev-flatpaks": set(),
         "owned-flatpaks": set(),
         "invited-flatpaks": set(),


### PR DESCRIPTION
The `display_name`s for the providers are kept up to date, but the one on FlathubUser is not.

Fixes #1497, sort of. We still don't update the display_name on FlathubUser, but we display the correct one in the user interface.