### PR TITLE
Handle fallback-x11 without wayland

### DIFF
--- a/frontend/src/safety.ts
+++ b/frontend/src/safety.ts
@@ -219,6 +219,23 @@ export function getSafetyRating(
       showOnSummaryOrDetails: "both",
     })
   }
+  /* "fallback-x11" without "wayland" means X11 */
+  if (
+    summary.metadata.permissions.sockets?.some(
+      (x) => x.toLowerCase() === "fallback-x11",
+    ) &&
+    !summary.metadata.permissions.sockets?.some(
+      (x) => x.toLowerCase() === "wayland",
+    )
+  ) {
+    appSafetyRating.push({
+      safetyRating: SafetyRating.potentially_unsafe,
+      title: "legacy-windowing-system",
+      description: "legacy-windowing-system-description",
+      icon: HiOutlineComputerDesktop,
+      showOnSummaryOrDetails: "both",
+    })
+  }
 
   // can acquire arbitrary permissions
   if (


### PR DESCRIPTION
Closes #1998

This is implemented in g-s via https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/1801/diffs