### PR TITLE
Allow githubOrgAccessLink to be undefined, as it is that while being …

### DIFF
--- a/frontend/src/components/application/AppVerificationControls/LoginVerification.tsx
+++ b/frontend/src/components/application/AppVerificationControls/LoginVerification.tsx
@@ -236,7 +236,7 @@ const LoginVerification: FunctionComponent<Props> = ({
               organization. You can grant this permission
               <a
                 className="no-underline hover:underline"
-                href={githubOrgAccessLink.data.link}
+                href={githubOrgAccessLink?.data?.link}
                 target="_blank"
                 rel="noreferrer"
               >


### PR DESCRIPTION
…called

I think this stems from the whole content assignment.
 Ideally, this should be moved into the html aprt.