### PR TITLE
Disable app-icon-size rule for now

### DIFF
--- a/backend/app/quality_moderation.py
+++ b/backend/app/quality_moderation.py
@@ -41,11 +41,12 @@ GUIDELINES = [
     GuidelineCategory(
         "app-icon",
         [
-            Guideline(
-                "app-icon-size",
-                "https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines/#icon-size",
-                datetime.datetime(2023, 9, 1),
-            ),
+            # This guideline can't be checked, as currently icons are a maximal size of 128x128
+            # Guideline(
+            #     "app-icon-size",
+            #     "https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines/#icon-size",
+            #     datetime.datetime(2023, 9, 1),
+            # ),
             Guideline(
                 "app-icon-footprint",
                 "https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines/#reasonable-footprint",

--- a/frontend/src/components/SlideOver.tsx
+++ b/frontend/src/components/SlideOver.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react"
 import { Dialog, Transition } from "@headlessui/react"
 import { HiMiniXMark } from "react-icons/hi2"
 import clsx from "clsx"
-import { useTranslation } from "react-i18next"
+import { useTranslation } from "next-i18next"
 
 export default function SlideOver({ shown, onClose, title, children }) {
   const { t } = useTranslation()

--- a/frontend/src/components/application/QualityModerationSlideOver.tsx
+++ b/frontend/src/components/application/QualityModerationSlideOver.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from "react-i18next"
 import {
   fetchQualityModerationForApp,
   postQualityModerationForApp,
@@ -28,6 +27,7 @@ import LogoImage from "../LogoImage"
 import { useCollapse } from "@collapsed/react"
 import Button from "../Button"
 import { IconGrid } from "./IconGrid"
+import { useTranslation } from "next-i18next"
 
 const QualityCategories = ({
   appId,


### PR DESCRIPTION
This should be enabled again, after we have ported to libappstream and get bigger icons.