### PR TITLE
Relax screenshot amount rule

### DIFF
--- a/backend/app/quality_moderation.py
+++ b/backend/app/quality_moderation.py
@@ -130,8 +130,8 @@ GUIDELINES = [
         "screenshots",
         [
             Guideline(
-                "screenshots-multiple-screenshots",
-                "https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines/#multiple-screenshots",
+                "screenshots-at-least-one-screenshot",
+                "https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/quality-guidelines/#at-least-one-screenshot",
                 datetime.datetime(2023, 9, 30),
                 read_only=True,
             ),

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -229,7 +229,7 @@ def update_quality_moderation():
                 models.QualityModeration.upsert(
                     sqldb,
                     app_id,
-                    "screenshots-multiple-screenshots",
-                    "screenshots" in value and len(value["screenshots"]) >= 2,
+                    "screenshots-at-least-one-screenshot",
+                    "screenshots" in value and len(value["screenshots"]) >= 1,
                     None,
                 )

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -489,7 +489,7 @@
     "show-icon": "Show icon",
     "hide-icon": "Hide icon",
     "screenshots": "Screenshots",
-    "screenshots-multiple-screenshots": "Two or more screenshots",
+    "screenshots-at-least-one-screenshot": "At least one screenshot",
     "screenshots-just-the-app-window": "Just the app window",
     "screenshots-take-screenshots-on-linux": "Screenshots taken on Linux",
     "screenshots-default-settings": "Default settings",


### PR DESCRIPTION
We changed the rule in the docs, due to some apps not being complicated enough, to have multiple screenshots.