### PR TITLE
feat: add codegen for frontend API client

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -86,5 +86,14 @@
                 "cwd": "${workspaceFolder}/backend"
             },
         },
+        {
+            "label": "codegen frontend",
+            "type": "shell",
+            "group": "build",
+            "command": "yarn openapi-codegen",
+            "options": {
+                "cwd": "${workspaceFolder}/frontend"
+            },
+        },
     ]
 }

--- a/backend/app/logins.py
+++ b/backend/app/logins.py
@@ -231,8 +231,13 @@ def login_state(request: Request) -> LoginInformation:
 LoginStatusDep = Annotated[LoginInformation, Depends(login_state)]
 
 
-@router.get("/login")
-def get_login_kinds():
+class LoginMethod(BaseModel):
+    method: str
+    name: str
+
+
+@router.get("/login", tags=["login"])
+def get_login_kinds() -> list[LoginMethod]:
     """
     Retrieve the login methods available from the backend.
 
@@ -244,22 +249,10 @@ def get_login_kinds():
     frontends with localisation may choose to render other text instead.
     """
     return [
-        {
-            "method": "github",
-            "name": "GitHub",
-        },
-        {
-            "method": "gitlab",
-            "name": "GitLab",
-        },
-        {
-            "method": "gnome",
-            "name": "GNOME GitLab",
-        },
-        {
-            "method": "kde",
-            "name": "KDE GitLab",
-        },
+        LoginMethod(method="github", name="GitHub"),
+        LoginMethod(method="gitlab", name="GitLab"),
+        LoginMethod(method="gnome", name="GNOME GitLab"),
+        LoginMethod(method="kde", name="KDE GitLab"),
     ]
 
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "postbuild": "next-sitemap",
-    "update-setup-instructions": "./setup-instructions.sh"
+    "update-setup-instructions": "./setup-instructions.sh",
+    "openapi-codegen": "openapi -i http://localhost:8000/openapi.json -o ./src/api -c axios"
   },
   "dependencies": {
     "@collapsed/react": "^4.0.1",
@@ -74,6 +75,7 @@
     "eslint-config-next": "^13.5.3",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "openapi-typescript-codegen": "^0.25.0",
     "postcss": "^8.4.31",
     "prettier": "^3.0.0",
     "prettier-plugin-tailwindcss": "^0.5.4",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -24,6 +24,10 @@ import { Error } from "../src/components/Error"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MotionConfig } from "framer-motion"
 
+// Set the correct base path for the API client
+import { OpenAPI } from "../src/api"
+OpenAPI.BASE = process.env.NEXT_PUBLIC_API_BASE_URI
+
 const inter = Inter({
   subsets: ["latin"],
   fallback: ["sans-serif"],

--- a/frontend/pages/login/[service].tsx
+++ b/frontend/pages/login/[service].tsx
@@ -8,7 +8,7 @@ import { toast } from "react-toastify"
 import { login } from "../../src/asyncs/login"
 import Spinner from "../../src/components/Spinner"
 import { useUserContext, useUserDispatch } from "../../src/context/user-info"
-import { fetchLoginProviders } from "../../src/fetchers"
+import { LoginService } from "../../src/api"
 import { useLocalStorage } from "../../src/hooks/useLocalStorage"
 import { usePendingTransaction } from "../../src/hooks/usePendingTransaction"
 import { isInternalRedirect } from "../../src/utils/security"
@@ -102,7 +102,7 @@ export default function AuthReturnPage({ services }: { services: string[] }) {
 }
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
-  const { data } = await fetchLoginProviders()
+  const data = await LoginService.getLoginKindsAuthLoginGet()
 
   const services = data.map((d) => d.method)
 

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -5,7 +5,7 @@ import Router from "next/router"
 import { useEffect } from "react"
 import LoginProviders from "../../src/components/login/Providers"
 import { useUserContext } from "../../src/context/user-info"
-import { fetchLoginProviders } from "../../src/fetchers"
+import { LoginService } from "../../src/api"
 import { useTranslation } from "next-i18next"
 
 export default function DeveloperLoginPortal({ providers, locale }) {
@@ -40,11 +40,9 @@ export default function DeveloperLoginPortal({ providers, locale }) {
 
 // Providers won't change often so fetch at build time for now
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
-  const { data: providers } = await fetchLoginProviders()
+  const providers = await LoginService.getLoginKindsAuthLoginGet()
 
-  // If request failed at build time, this page becomes a 404
   return {
-    notFound: !providers,
     props: {
       ...(await serverSideTranslations(locale, ["common"])),
       providers,

--- a/frontend/pages/my-flathub.tsx
+++ b/frontend/pages/my-flathub.tsx
@@ -6,7 +6,7 @@ import LoginGuard from "../src/components/login/LoginGuard"
 import DeleteButton from "../src/components/user/DeleteButton"
 import UserDetails from "../src/components/user/Details"
 import UserApps from "../src/components/user/UserApps"
-import { fetchLoginProviders } from "../src/fetchers"
+import { LoginService } from "../src/api"
 import { LoginProvider } from "../src/types/Login"
 import { IS_PRODUCTION } from "src/env"
 import Tabs from "src/components/Tabs"
@@ -126,7 +126,7 @@ export default function Userpage({
 
 // Need available login providers to show options on page
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
-  const { data: providers } = await fetchLoginProviders()
+  const providers = await LoginService.getLoginKindsAuthLoginGet()
 
   return {
     props: {

--- a/frontend/src/api/core/ApiError.ts
+++ b/frontend/src/api/core/ApiError.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+
+export class ApiError extends Error {
+    public readonly url: string;
+    public readonly status: number;
+    public readonly statusText: string;
+    public readonly body: any;
+    public readonly request: ApiRequestOptions;
+
+    constructor(request: ApiRequestOptions, response: ApiResult, message: string) {
+        super(message);
+
+        this.name = 'ApiError';
+        this.url = response.url;
+        this.status = response.status;
+        this.statusText = response.statusText;
+        this.body = response.body;
+        this.request = request;
+    }
+}

--- a/frontend/src/api/core/ApiRequestOptions.ts
+++ b/frontend/src/api/core/ApiRequestOptions.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+    readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
+    readonly url: string;
+    readonly path?: Record<string, any>;
+    readonly cookies?: Record<string, any>;
+    readonly headers?: Record<string, any>;
+    readonly query?: Record<string, any>;
+    readonly formData?: Record<string, any>;
+    readonly body?: any;
+    readonly mediaType?: string;
+    readonly responseHeader?: string;
+    readonly errors?: Record<number, string>;
+};

--- a/frontend/src/api/core/ApiResult.ts
+++ b/frontend/src/api/core/ApiResult.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+    readonly url: string;
+    readonly ok: boolean;
+    readonly status: number;
+    readonly statusText: string;
+    readonly body: any;
+};

--- a/frontend/src/api/core/CancelablePromise.ts
+++ b/frontend/src/api/core/CancelablePromise.ts
@@ -1,0 +1,131 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+
+    constructor(message: string) {
+        super(message);
+        this.name = 'CancelError';
+    }
+
+    public get isCancelled(): boolean {
+        return true;
+    }
+}
+
+export interface OnCancel {
+    readonly isResolved: boolean;
+    readonly isRejected: boolean;
+    readonly isCancelled: boolean;
+
+    (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+    #isResolved: boolean;
+    #isRejected: boolean;
+    #isCancelled: boolean;
+    readonly #cancelHandlers: (() => void)[];
+    readonly #promise: Promise<T>;
+    #resolve?: (value: T | PromiseLike<T>) => void;
+    #reject?: (reason?: any) => void;
+
+    constructor(
+        executor: (
+            resolve: (value: T | PromiseLike<T>) => void,
+            reject: (reason?: any) => void,
+            onCancel: OnCancel
+        ) => void
+    ) {
+        this.#isResolved = false;
+        this.#isRejected = false;
+        this.#isCancelled = false;
+        this.#cancelHandlers = [];
+        this.#promise = new Promise<T>((resolve, reject) => {
+            this.#resolve = resolve;
+            this.#reject = reject;
+
+            const onResolve = (value: T | PromiseLike<T>): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isResolved = true;
+                this.#resolve?.(value);
+            };
+
+            const onReject = (reason?: any): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#isRejected = true;
+                this.#reject?.(reason);
+            };
+
+            const onCancel = (cancelHandler: () => void): void => {
+                if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+                    return;
+                }
+                this.#cancelHandlers.push(cancelHandler);
+            };
+
+            Object.defineProperty(onCancel, 'isResolved', {
+                get: (): boolean => this.#isResolved,
+            });
+
+            Object.defineProperty(onCancel, 'isRejected', {
+                get: (): boolean => this.#isRejected,
+            });
+
+            Object.defineProperty(onCancel, 'isCancelled', {
+                get: (): boolean => this.#isCancelled,
+            });
+
+            return executor(onResolve, onReject, onCancel as OnCancel);
+        });
+    }
+
+     get [Symbol.toStringTag]() {
+            return "Cancellable Promise";
+     }
+
+    public then<TResult1 = T, TResult2 = never>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+    ): Promise<TResult1 | TResult2> {
+        return this.#promise.then(onFulfilled, onRejected);
+    }
+
+    public catch<TResult = never>(
+        onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null
+    ): Promise<T | TResult> {
+        return this.#promise.catch(onRejected);
+    }
+
+    public finally(onFinally?: (() => void) | null): Promise<T> {
+        return this.#promise.finally(onFinally);
+    }
+
+    public cancel(): void {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+            return;
+        }
+        this.#isCancelled = true;
+        if (this.#cancelHandlers.length) {
+            try {
+                for (const cancelHandler of this.#cancelHandlers) {
+                    cancelHandler();
+                }
+            } catch (error) {
+                console.warn('Cancellation threw an error', error);
+                return;
+            }
+        }
+        this.#cancelHandlers.length = 0;
+        this.#reject?.(new CancelError('Request aborted'));
+    }
+
+    public get isCancelled(): boolean {
+        return this.#isCancelled;
+    }
+}

--- a/frontend/src/api/core/OpenAPI.ts
+++ b/frontend/src/api/core/OpenAPI.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from './ApiRequestOptions';
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+    BASE: string;
+    VERSION: string;
+    WITH_CREDENTIALS: boolean;
+    CREDENTIALS: 'include' | 'omit' | 'same-origin';
+    TOKEN?: string | Resolver<string> | undefined;
+    USERNAME?: string | Resolver<string> | undefined;
+    PASSWORD?: string | Resolver<string> | undefined;
+    HEADERS?: Headers | Resolver<Headers> | undefined;
+    ENCODE_PATH?: ((path: string) => string) | undefined;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+    BASE: '',
+    VERSION: '0.1.0',
+    WITH_CREDENTIALS: false,
+    CREDENTIALS: 'include',
+    TOKEN: undefined,
+    USERNAME: undefined,
+    PASSWORD: undefined,
+    HEADERS: undefined,
+    ENCODE_PATH: undefined,
+};

--- a/frontend/src/api/core/request.ts
+++ b/frontend/src/api/core/request.ts
@@ -1,0 +1,319 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import axios from 'axios';
+import type { AxiosError, AxiosRequestConfig, AxiosResponse, AxiosInstance } from 'axios';
+import FormData from 'form-data';
+
+import { ApiError } from './ApiError';
+import type { ApiRequestOptions } from './ApiRequestOptions';
+import type { ApiResult } from './ApiResult';
+import { CancelablePromise } from './CancelablePromise';
+import type { OnCancel } from './CancelablePromise';
+import type { OpenAPIConfig } from './OpenAPI';
+
+export const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
+    return value !== undefined && value !== null;
+};
+
+export const isString = (value: any): value is string => {
+    return typeof value === 'string';
+};
+
+export const isStringWithValue = (value: any): value is string => {
+    return isString(value) && value !== '';
+};
+
+export const isBlob = (value: any): value is Blob => {
+    return (
+        typeof value === 'object' &&
+        typeof value.type === 'string' &&
+        typeof value.stream === 'function' &&
+        typeof value.arrayBuffer === 'function' &&
+        typeof value.constructor === 'function' &&
+        typeof value.constructor.name === 'string' &&
+        /^(Blob|File)$/.test(value.constructor.name) &&
+        /^(Blob|File)$/.test(value[Symbol.toStringTag])
+    );
+};
+
+export const isFormData = (value: any): value is FormData => {
+    return value instanceof FormData;
+};
+
+export const isSuccess = (status: number): boolean => {
+    return status >= 200 && status < 300;
+};
+
+export const base64 = (str: string): string => {
+    try {
+        return btoa(str);
+    } catch (err) {
+        // @ts-ignore
+        return Buffer.from(str).toString('base64');
+    }
+};
+
+export const getQueryString = (params: Record<string, any>): string => {
+    const qs: string[] = [];
+
+    const append = (key: string, value: any) => {
+        qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    };
+
+    const process = (key: string, value: any) => {
+        if (isDefined(value)) {
+            if (Array.isArray(value)) {
+                value.forEach(v => {
+                    process(key, v);
+                });
+            } else if (typeof value === 'object') {
+                Object.entries(value).forEach(([k, v]) => {
+                    process(`${key}[${k}]`, v);
+                });
+            } else {
+                append(key, value);
+            }
+        }
+    };
+
+    Object.entries(params).forEach(([key, value]) => {
+        process(key, value);
+    });
+
+    if (qs.length > 0) {
+        return `?${qs.join('&')}`;
+    }
+
+    return '';
+};
+
+const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+    const encoder = config.ENCODE_PATH || encodeURI;
+
+    const path = options.url
+        .replace('{api-version}', config.VERSION)
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
+            if (options.path?.hasOwnProperty(group)) {
+                return encoder(String(options.path[group]));
+            }
+            return substring;
+        });
+
+    const url = `${config.BASE}${path}`;
+    if (options.query) {
+        return `${url}${getQueryString(options.query)}`;
+    }
+    return url;
+};
+
+export const getFormData = (options: ApiRequestOptions): FormData | undefined => {
+    if (options.formData) {
+        const formData = new FormData();
+
+        const process = (key: string, value: any) => {
+            if (isString(value) || isBlob(value)) {
+                formData.append(key, value);
+            } else {
+                formData.append(key, JSON.stringify(value));
+            }
+        };
+
+        Object.entries(options.formData)
+            .filter(([_, value]) => isDefined(value))
+            .forEach(([key, value]) => {
+                if (Array.isArray(value)) {
+                    value.forEach(v => process(key, v));
+                } else {
+                    process(key, value);
+                }
+            });
+
+        return formData;
+    }
+    return undefined;
+};
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+export const resolve = async <T>(options: ApiRequestOptions, resolver?: T | Resolver<T>): Promise<T | undefined> => {
+    if (typeof resolver === 'function') {
+        return (resolver as Resolver<T>)(options);
+    }
+    return resolver;
+};
+
+export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptions, formData?: FormData): Promise<Record<string, string>> => {
+    const token = await resolve(options, config.TOKEN);
+    const username = await resolve(options, config.USERNAME);
+    const password = await resolve(options, config.PASSWORD);
+    const additionalHeaders = await resolve(options, config.HEADERS);
+    const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
+
+    const headers = Object.entries({
+        Accept: 'application/json',
+        ...additionalHeaders,
+        ...options.headers,
+        ...formHeaders,
+    })
+    .filter(([_, value]) => isDefined(value))
+    .reduce((headers, [key, value]) => ({
+        ...headers,
+        [key]: String(value),
+    }), {} as Record<string, string>);
+
+    if (isStringWithValue(token)) {
+        headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    if (isStringWithValue(username) && isStringWithValue(password)) {
+        const credentials = base64(`${username}:${password}`);
+        headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (options.body) {
+        if (options.mediaType) {
+            headers['Content-Type'] = options.mediaType;
+        } else if (isBlob(options.body)) {
+            headers['Content-Type'] = options.body.type || 'application/octet-stream';
+        } else if (isString(options.body)) {
+            headers['Content-Type'] = 'text/plain';
+        } else if (!isFormData(options.body)) {
+            headers['Content-Type'] = 'application/json';
+        }
+    }
+
+    return headers;
+};
+
+export const getRequestBody = (options: ApiRequestOptions): any => {
+    if (options.body) {
+        return options.body;
+    }
+    return undefined;
+};
+
+export const sendRequest = async <T>(
+    config: OpenAPIConfig,
+    options: ApiRequestOptions,
+    url: string,
+    body: any,
+    formData: FormData | undefined,
+    headers: Record<string, string>,
+    onCancel: OnCancel,
+    axiosClient: AxiosInstance
+): Promise<AxiosResponse<T>> => {
+    const source = axios.CancelToken.source();
+
+    const requestConfig: AxiosRequestConfig = {
+        url,
+        headers,
+        data: body ?? formData,
+        method: options.method,
+        withCredentials: config.WITH_CREDENTIALS,
+        cancelToken: source.token,
+    };
+
+    onCancel(() => source.cancel('The user aborted a request.'));
+
+    try {
+        return await axiosClient.request(requestConfig);
+    } catch (error) {
+        const axiosError = error as AxiosError<T>;
+        if (axiosError.response) {
+            return axiosError.response;
+        }
+        throw error;
+    }
+};
+
+export const getResponseHeader = (response: AxiosResponse<any>, responseHeader?: string): string | undefined => {
+    if (responseHeader) {
+        const content = response.headers[responseHeader];
+        if (isString(content)) {
+            return content;
+        }
+    }
+    return undefined;
+};
+
+export const getResponseBody = (response: AxiosResponse<any>): any => {
+    if (response.status !== 204) {
+        return response.data;
+    }
+    return undefined;
+};
+
+export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): void => {
+    const errors: Record<number, string> = {
+        400: 'Bad Request',
+        401: 'Unauthorized',
+        403: 'Forbidden',
+        404: 'Not Found',
+        500: 'Internal Server Error',
+        502: 'Bad Gateway',
+        503: 'Service Unavailable',
+        ...options.errors,
+    }
+
+    const error = errors[result.status];
+    if (error) {
+        throw new ApiError(options, result, error);
+    }
+
+    if (!result.ok) {
+        const errorStatus = result.status ?? 'unknown';
+        const errorStatusText = result.statusText ?? 'unknown';
+        const errorBody = (() => {
+            try {
+                return JSON.stringify(result.body, null, 2);
+            } catch (e) {
+                return undefined;
+            }
+        })();
+
+        throw new ApiError(options, result,
+            `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`
+        );
+    }
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @param axiosClient The axios client instance to use
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
+    return new CancelablePromise(async (resolve, reject, onCancel) => {
+        try {
+            const url = getUrl(config, options);
+            const formData = getFormData(options);
+            const body = getRequestBody(options);
+            const headers = await getHeaders(config, options, formData);
+
+            if (!onCancel.isCancelled) {
+                const response = await sendRequest<T>(config, options, url, body, formData, headers, onCancel, axiosClient);
+                const responseBody = getResponseBody(response);
+                const responseHeader = getResponseHeader(response, options.responseHeader);
+
+                const result: ApiResult = {
+                    url,
+                    ok: isSuccess(response.status),
+                    status: response.status,
+                    statusText: response.statusText,
+                    body: responseHeader ?? responseBody,
+                };
+
+                catchErrorCodes(options, result);
+
+                resolve(result.body);
+            }
+        } catch (error) {
+            reject(error);
+        }
+    });
+};

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,71 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+
+export { AvailableLoginMethodStatus } from './models/AvailableLoginMethodStatus';
+export type { AvailableMethod } from './models/AvailableMethod';
+export type { AvailableMethods } from './models/AvailableMethods';
+export { AvailableMethodType } from './models/AvailableMethodType';
+export type { Body_get_download_token_purchases_generate_download_token_post } from './models/Body_get_download_token_purchases_generate_download_token_post';
+export type { BuildNotificationRequest } from './models/BuildNotificationRequest';
+export type { CardInfo } from './models/CardInfo';
+export { ConnectedAccountProvider } from './models/ConnectedAccountProvider';
+export type { Developer } from './models/Developer';
+export type { DevelopersResponse } from './models/DevelopersResponse';
+export { ErrorDetail } from './models/ErrorDetail';
+export type { Filter } from './models/Filter';
+export type { HTTPValidationError } from './models/HTTPValidationError';
+export type { InviteStatus } from './models/InviteStatus';
+export type { LinkResponse } from './models/LinkResponse';
+export type { LoginMethod } from './models/LoginMethod';
+export { LoginProvider } from './models/LoginProvider';
+export { MainCategory } from './models/MainCategory';
+export type { ModerationApp } from './models/ModerationApp';
+export type { ModerationAppItem } from './models/ModerationAppItem';
+export type { ModerationAppsResponse } from './models/ModerationAppsResponse';
+export type { ModerationRequestResponse } from './models/ModerationRequestResponse';
+export type { ModerationRequestType } from './models/ModerationRequestType';
+export type { NascentTransaction } from './models/NascentTransaction';
+export { NascentTransactionSummary } from './models/NascentTransactionSummary';
+export type { OauthLoginResponseFailure } from './models/OauthLoginResponseFailure';
+export type { OauthLoginResponseSuccess } from './models/OauthLoginResponseSuccess';
+export type { Platform } from './models/Platform';
+export type { PricingInfo } from './models/PricingInfo';
+export type { ProposedPayment } from './models/ProposedPayment';
+export type { RedemptionResult } from './models/RedemptionResult';
+export type { Review } from './models/Review';
+export type { ReviewItem } from './models/ReviewItem';
+export type { ReviewRequest } from './models/ReviewRequest';
+export type { ReviewRequestResponse } from './models/ReviewRequestResponse';
+export type { SearchQuery } from './models/SearchQuery';
+export type { StorefrontInfo } from './models/StorefrontInfo';
+export type { TokenCancellation } from './models/TokenCancellation';
+export type { TokenList } from './models/TokenList';
+export type { TokenModel } from './models/TokenModel';
+export type { Transaction } from './models/Transaction';
+export { TransactionRow } from './models/TransactionRow';
+export type { TransactionSaveCard } from './models/TransactionSaveCard';
+export { TransactionSortOrder } from './models/TransactionSortOrder';
+export { TransactionSummary } from './models/TransactionSummary';
+export type { UpsertQualityModeration } from './models/UpsertQualityModeration';
+export type { UserDeleteRequest } from './models/UserDeleteRequest';
+export type { ValidationError } from './models/ValidationError';
+export { VendingApplicationInformation } from './models/VendingApplicationInformation';
+export type { VendingConfig } from './models/VendingConfig';
+export type { VendingOnboardingRequest } from './models/VendingOnboardingRequest';
+export type { VendingOutput } from './models/VendingOutput';
+export type { VendingRedirect } from './models/VendingRedirect';
+export type { VendingSetup } from './models/VendingSetup';
+export type { VendingStatus } from './models/VendingStatus';
+export { VerificationMethod } from './models/VerificationMethod';
+export type { VerificationStatus } from './models/VerificationStatus';
+export type { WebsiteVerificationResult } from './models/WebsiteVerificationResult';
+export type { WebsiteVerificationToken } from './models/WebsiteVerificationToken';
+
+export { DefaultService } from './services/DefaultService';
+export { LoginService } from './services/LoginService';

--- a/frontend/src/api/models/AvailableLoginMethodStatus.ts
+++ b/frontend/src/api/models/AvailableLoginMethodStatus.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum AvailableLoginMethodStatus {
+    READY = 'ready',
+    USER_DOES_NOT_EXIST = 'user_does_not_exist',
+    USERNAME_DOES_NOT_MATCH = 'username_does_not_match',
+    PROVIDER_DENIED_ACCESS = 'provider_denied_access',
+    NOT_LOGGED_IN = 'not_logged_in',
+    NOT_ORG_MEMBER = 'not_org_member',
+    NOT_ORG_ADMIN = 'not_org_admin',
+}

--- a/frontend/src/api/models/AvailableMethod.ts
+++ b/frontend/src/api/models/AvailableMethod.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { AvailableLoginMethodStatus } from './AvailableLoginMethodStatus';
+import type { AvailableMethodType } from './AvailableMethodType';
+import type { LoginProvider } from './LoginProvider';
+
+export type AvailableMethod = {
+    method: AvailableMethodType;
+    website: (string | null);
+    website_token: (string | null);
+    login_provider: (LoginProvider | null);
+    login_name: (string | null);
+    login_is_organization: (boolean | null);
+    login_status: (AvailableLoginMethodStatus | null);
+};
+

--- a/frontend/src/api/models/AvailableMethodType.ts
+++ b/frontend/src/api/models/AvailableMethodType.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum AvailableMethodType {
+    WEBSITE = 'website',
+    LOGIN_PROVIDER = 'login_provider',
+}

--- a/frontend/src/api/models/AvailableMethods.ts
+++ b/frontend/src/api/models/AvailableMethods.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { AvailableMethod } from './AvailableMethod';
+
+export type AvailableMethods = {
+    methods: (Array<AvailableMethod> | null);
+    detail: (string | null);
+};
+

--- a/frontend/src/api/models/Body_get_download_token_purchases_generate_download_token_post.ts
+++ b/frontend/src/api/models/Body_get_download_token_purchases_generate_download_token_post.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Body_get_download_token_purchases_generate_download_token_post = {
+    appids: Array<string>;
+    update_token?: string;
+};
+

--- a/frontend/src/api/models/BuildNotificationRequest.ts
+++ b/frontend/src/api/models/BuildNotificationRequest.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type BuildNotificationRequest = {
+    app_id: string;
+    build_id: number;
+    build_repo: string;
+    diagnostics: Array<any>;
+};
+

--- a/frontend/src/api/models/CardInfo.ts
+++ b/frontend/src/api/models/CardInfo.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type CardInfo = {
+    id: string;
+    brand: string;
+    country: string;
+    exp_month: number;
+    exp_year: number;
+    last4: string;
+};
+

--- a/frontend/src/api/models/ConnectedAccountProvider.ts
+++ b/frontend/src/api/models/ConnectedAccountProvider.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum ConnectedAccountProvider {
+    GITHUB = 'github',
+    GITLAB = 'gitlab',
+    GNOME = 'gnome',
+    GOOGLE = 'google',
+    KDE = 'kde',
+}

--- a/frontend/src/api/models/Developer.ts
+++ b/frontend/src/api/models/Developer.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Developer = {
+    id: number;
+    is_self: boolean;
+    name: (string | null);
+    is_primary: (boolean | null);
+};
+

--- a/frontend/src/api/models/DevelopersResponse.ts
+++ b/frontend/src/api/models/DevelopersResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { Developer } from './Developer';
+
+export type DevelopersResponse = {
+    developers: Array<Developer>;
+    invites: Array<Developer>;
+};
+

--- a/frontend/src/api/models/ErrorDetail.ts
+++ b/frontend/src/api/models/ErrorDetail.ts
@@ -1,0 +1,25 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum ErrorDetail {
+    MALFORMED_APP_ID = 'malformed_app_id',
+    NOT_APP_DEVELOPER = 'not_app_developer',
+    INVALID_METHOD = 'invalid_method',
+    FAILED_TO_CONNECT = 'failed_to_connect',
+    SERVER_RETURNED_ERROR = 'server_returned_error',
+    APP_NOT_LISTED = 'app_not_listed',
+    BLOCKED_BY_ADMINS = 'blocked_by_admins',
+    NOT_LOGGED_IN = 'not_logged_in',
+    USERNAME_DOES_NOT_MATCH = 'username_does_not_match',
+    USER_DOES_NOT_EXIST = 'user_does_not_exist',
+    PROVIDER_ERROR = 'provider_error',
+    PROVIDER_DENIED_ACCESS = 'provider_denied_access',
+    NOT_ORG_MEMBER = 'not_org_member',
+    NOT_ORG_ADMIN = 'not_org_admin',
+    APP_ALREADY_VERIFIED = 'app_already_verified',
+    MUST_SET_UP_FIRST = 'must_set_up_first',
+    APP_ALREADY_EXISTS = 'app_already_exists',
+    MUST_ACCEPT_PUBLISHER_AGREEMENT = 'must_accept_publisher_agreement',
+}

--- a/frontend/src/api/models/Filter.ts
+++ b/frontend/src/api/models/Filter.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Filter = {
+    filterType: string;
+    value: string;
+};
+

--- a/frontend/src/api/models/HTTPValidationError.ts
+++ b/frontend/src/api/models/HTTPValidationError.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ValidationError } from './ValidationError';
+
+export type HTTPValidationError = {
+    detail?: Array<ValidationError>;
+};
+

--- a/frontend/src/api/models/InviteStatus.ts
+++ b/frontend/src/api/models/InviteStatus.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type InviteStatus = {
+    is_pending: boolean;
+    is_direct_upload_app: boolean;
+};
+

--- a/frontend/src/api/models/LinkResponse.ts
+++ b/frontend/src/api/models/LinkResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type LinkResponse = {
+    link: string;
+};
+

--- a/frontend/src/api/models/LoginMethod.ts
+++ b/frontend/src/api/models/LoginMethod.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type LoginMethod = {
+    method: string;
+    name: string;
+};
+

--- a/frontend/src/api/models/LoginProvider.ts
+++ b/frontend/src/api/models/LoginProvider.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum LoginProvider {
+    GITHUB = 'github',
+    GITLAB = 'gitlab',
+    GNOME = 'gnome',
+    KDE = 'kde',
+}

--- a/frontend/src/api/models/MainCategory.ts
+++ b/frontend/src/api/models/MainCategory.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum MainCategory {
+    AUDIOVIDEO = 'audiovideo',
+    DEVELOPMENT = 'development',
+    EDUCATION = 'education',
+    GAME = 'game',
+    GRAPHICS = 'graphics',
+    NETWORK = 'network',
+    OFFICE = 'office',
+    SCIENCE = 'science',
+    SYSTEM = 'system',
+    UTILITY = 'utility',
+}

--- a/frontend/src/api/models/ModerationApp.ts
+++ b/frontend/src/api/models/ModerationApp.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModerationRequestResponse } from './ModerationRequestResponse';
+
+export type ModerationApp = {
+    requests: Array<ModerationRequestResponse>;
+    requests_count: number;
+};
+

--- a/frontend/src/api/models/ModerationAppItem.ts
+++ b/frontend/src/api/models/ModerationAppItem.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModerationRequestType } from './ModerationRequestType';
+
+export type ModerationAppItem = {
+    app_id: string;
+    is_new_submission: boolean;
+    updated_at: (string | null);
+    request_types: Array<ModerationRequestType>;
+};
+

--- a/frontend/src/api/models/ModerationAppsResponse.ts
+++ b/frontend/src/api/models/ModerationAppsResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModerationAppItem } from './ModerationAppItem';
+
+export type ModerationAppsResponse = {
+    apps: Array<ModerationAppItem>;
+    apps_count: number;
+};
+

--- a/frontend/src/api/models/ModerationRequestResponse.ts
+++ b/frontend/src/api/models/ModerationRequestResponse.ts
@@ -1,0 +1,23 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ModerationRequestType } from './ModerationRequestType';
+
+export type ModerationRequestResponse = {
+    id: number;
+    app_id: string;
+    created_at: number;
+    build_id: number;
+    job_id: number;
+    is_outdated: boolean;
+    request_type: ModerationRequestType;
+    request_data: null;
+    is_new_submission: boolean;
+    handled_by: (string | null);
+    handled_at: (number | null);
+    is_approved: (boolean | null);
+    comment: (string | null);
+};
+

--- a/frontend/src/api/models/ModerationRequestType.ts
+++ b/frontend/src/api/models/ModerationRequestType.ts
@@ -1,0 +1,6 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ModerationRequestType = string;

--- a/frontend/src/api/models/NascentTransaction.ts
+++ b/frontend/src/api/models/NascentTransaction.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { NascentTransactionSummary } from './NascentTransactionSummary';
+import type { TransactionRow } from './TransactionRow';
+
+export type NascentTransaction = {
+    summary: NascentTransactionSummary;
+    details: Array<TransactionRow>;
+};
+

--- a/frontend/src/api/models/NascentTransactionSummary.ts
+++ b/frontend/src/api/models/NascentTransactionSummary.ts
@@ -1,0 +1,21 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type NascentTransactionSummary = {
+    value: number;
+    currency: string;
+    kind: NascentTransactionSummary.kind;
+};
+
+export namespace NascentTransactionSummary {
+
+    export enum kind {
+        DONATION = 'donation',
+        PURCHASE = 'purchase',
+    }
+
+
+}
+

--- a/frontend/src/api/models/OauthLoginResponseFailure.ts
+++ b/frontend/src/api/models/OauthLoginResponseFailure.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type OauthLoginResponseFailure = {
+    state: string;
+    error: string;
+    error_description?: (string | null);
+    error_uri?: (string | null);
+};
+

--- a/frontend/src/api/models/OauthLoginResponseSuccess.ts
+++ b/frontend/src/api/models/OauthLoginResponseSuccess.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type OauthLoginResponseSuccess = {
+    code: string;
+    state: string;
+};
+

--- a/frontend/src/api/models/Platform.ts
+++ b/frontend/src/api/models/Platform.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ *
+ * A platform is an expression of dependencies which an application may have.
+ * Applications nominally express a single platform key for themselves, or
+ * none at all if they do not need one.  But platforms may depend on one another.
+ *
+ * If no platform is specified for an application, it's worth getting the default
+ * platform and using that.
+ *
+ */
+export type Platform = {
+    depends: (string | null);
+    aliases: Array<string>;
+    keep: number;
+    stripe_account: (string | null);
+};
+

--- a/frontend/src/api/models/PricingInfo.ts
+++ b/frontend/src/api/models/PricingInfo.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type PricingInfo = {
+    recommended_donation: (number | null);
+    minimum_payment: (number | null);
+};
+

--- a/frontend/src/api/models/ProposedPayment.ts
+++ b/frontend/src/api/models/ProposedPayment.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ *
+ * Proposed payment to be made for an application
+ *
+ */
+export type ProposedPayment = {
+    currency: string;
+    amount: number;
+};
+

--- a/frontend/src/api/models/RedemptionResult.ts
+++ b/frontend/src/api/models/RedemptionResult.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type RedemptionResult = {
+    status: string;
+    reason: string;
+};
+

--- a/frontend/src/api/models/Review.ts
+++ b/frontend/src/api/models/Review.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Review = {
+    approve: boolean;
+    comment?: (string | null);
+};
+

--- a/frontend/src/api/models/ReviewItem.ts
+++ b/frontend/src/api/models/ReviewItem.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ReviewItem = {
+    name?: (string | null);
+    summary?: (string | null);
+    developer_name?: (string | null);
+    project_license?: (string | null);
+    project_group?: (string | null);
+    compulsory_for_desktop?: (boolean | null);
+};
+

--- a/frontend/src/api/models/ReviewRequest.ts
+++ b/frontend/src/api/models/ReviewRequest.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ReviewItem } from './ReviewItem';
+
+export type ReviewRequest = {
+    build_id: number;
+    job_id: number;
+    app_metadata: Record<string, ReviewItem>;
+};
+

--- a/frontend/src/api/models/ReviewRequestResponse.ts
+++ b/frontend/src/api/models/ReviewRequestResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ReviewRequestResponse = {
+    requires_review: boolean;
+};
+

--- a/frontend/src/api/models/SearchQuery.ts
+++ b/frontend/src/api/models/SearchQuery.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { Filter } from './Filter';
+
+export type SearchQuery = {
+    query: string;
+    filters?: (Array<Filter> | null);
+};
+

--- a/frontend/src/api/models/StorefrontInfo.ts
+++ b/frontend/src/api/models/StorefrontInfo.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { PricingInfo } from './PricingInfo';
+import type { VerificationStatus } from './VerificationStatus';
+
+export type StorefrontInfo = {
+    verification: (VerificationStatus | null);
+    pricing: (PricingInfo | null);
+    is_free_software: boolean;
+};
+

--- a/frontend/src/api/models/TokenCancellation.ts
+++ b/frontend/src/api/models/TokenCancellation.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TokenCancellation = {
+    token: string;
+    status: string;
+};
+

--- a/frontend/src/api/models/TokenList.ts
+++ b/frontend/src/api/models/TokenList.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { TokenModel } from './TokenModel';
+
+export type TokenList = {
+    status: string;
+    total: number;
+    tokens: Array<TokenModel>;
+};
+

--- a/frontend/src/api/models/TokenModel.ts
+++ b/frontend/src/api/models/TokenModel.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TokenModel = {
+    id: string;
+    state: string;
+    name: string;
+    token: (string | null);
+    created: string;
+    changed: string;
+};
+

--- a/frontend/src/api/models/Transaction.ts
+++ b/frontend/src/api/models/Transaction.ts
@@ -1,0 +1,16 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CardInfo } from './CardInfo';
+import type { TransactionRow } from './TransactionRow';
+import type { TransactionSummary } from './TransactionSummary';
+
+export type Transaction = {
+    summary: TransactionSummary;
+    card: (CardInfo | null);
+    details: Array<TransactionRow>;
+    receipt: (string | null);
+};
+

--- a/frontend/src/api/models/TransactionRow.ts
+++ b/frontend/src/api/models/TransactionRow.ts
@@ -1,0 +1,22 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TransactionRow = {
+    recipient: string;
+    amount: number;
+    currency: string;
+    kind: TransactionRow.kind;
+};
+
+export namespace TransactionRow {
+
+    export enum kind {
+        DONATION = 'donation',
+        PURCHASE = 'purchase',
+    }
+
+
+}
+

--- a/frontend/src/api/models/TransactionSaveCard.ts
+++ b/frontend/src/api/models/TransactionSaveCard.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TransactionSaveCard = {
+    save_card?: ('off_session' | 'on_session' | null);
+};
+

--- a/frontend/src/api/models/TransactionSortOrder.ts
+++ b/frontend/src/api/models/TransactionSortOrder.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Sorting of transactions, either most-recent first, or oldest first
+ */
+export enum TransactionSortOrder {
+    RECENT = 'recent',
+    OLDEST = 'oldest',
+}

--- a/frontend/src/api/models/TransactionSummary.ts
+++ b/frontend/src/api/models/TransactionSummary.ts
@@ -1,0 +1,26 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TransactionSummary = {
+    id: string;
+    value: number;
+    currency: string;
+    kind: TransactionSummary.kind;
+    status: string;
+    reason: (string | null);
+    created: (number | null);
+    updated: (number | null);
+};
+
+export namespace TransactionSummary {
+
+    export enum kind {
+        DONATION = 'donation',
+        PURCHASE = 'purchase',
+    }
+
+
+}
+

--- a/frontend/src/api/models/UpsertQualityModeration.ts
+++ b/frontend/src/api/models/UpsertQualityModeration.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type UpsertQualityModeration = {
+    guideline_id: string;
+    passed: boolean;
+};
+

--- a/frontend/src/api/models/UserDeleteRequest.ts
+++ b/frontend/src/api/models/UserDeleteRequest.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type UserDeleteRequest = {
+    token: string;
+};
+

--- a/frontend/src/api/models/ValidationError.ts
+++ b/frontend/src/api/models/ValidationError.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ValidationError = {
+    loc: Array<(string | number)>;
+    msg: string;
+    type: string;
+};
+

--- a/frontend/src/api/models/VendingApplicationInformation.ts
+++ b/frontend/src/api/models/VendingApplicationInformation.ts
@@ -1,0 +1,29 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ *
+ * Information about an app, including tax code etc
+ *
+ */
+export type VendingApplicationInformation = {
+    app_id: string;
+    kind: VendingApplicationInformation.kind;
+    kind_reason: string;
+    foss: boolean;
+    foss_reason: string;
+};
+
+export namespace VendingApplicationInformation {
+
+    export enum kind {
+        GAME = 'GAME',
+        PRODUCTIVITY = 'PRODUCTIVITY',
+        GENERIC = 'GENERIC',
+    }
+
+
+}
+

--- a/frontend/src/api/models/VendingConfig.ts
+++ b/frontend/src/api/models/VendingConfig.ts
@@ -1,0 +1,20 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { Platform } from './Platform';
+
+/**
+ *
+ * Global vending environment configuration values
+ *
+ */
+export type VendingConfig = {
+    status: string;
+    platforms: Record<string, Platform>;
+    fee_fixed_cost: number;
+    fee_cost_percent: number;
+    fee_prefer_percent: number;
+};
+

--- a/frontend/src/api/models/VendingOnboardingRequest.ts
+++ b/frontend/src/api/models/VendingOnboardingRequest.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ *
+ * A request to begin/continue the onboarding process for a user.
+ *
+ * Any onboarding operation request a 'return' URL which we will tell Stripe
+ * to send us back to.
+ *
+ */
+export type VendingOnboardingRequest = {
+    return_url: string;
+};
+

--- a/frontend/src/api/models/VendingOutput.ts
+++ b/frontend/src/api/models/VendingOutput.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ *
+ * Result from attempting to make a proposed payment
+ *
+ */
+export type VendingOutput = {
+    status: string;
+    transaction: string;
+};
+

--- a/frontend/src/api/models/VendingRedirect.ts
+++ b/frontend/src/api/models/VendingRedirect.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ *
+ * Any redirect the vending system needs to create will be returned like this.
+ *
+ * Status will be "ok" otherwise you cannot rely on target_url and instead
+ * something look for like error.
+ *
+ */
+export type VendingRedirect = {
+    status: string;
+    target_url: string;
+};
+

--- a/frontend/src/api/models/VendingSetup.ts
+++ b/frontend/src/api/models/VendingSetup.ts
@@ -1,0 +1,17 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ *
+ * Configuration for a vended application
+ *
+ */
+export type VendingSetup = {
+    currency: string;
+    appshare: number;
+    recommended_donation: number;
+    minimum_payment: number;
+};
+

--- a/frontend/src/api/models/VendingStatus.ts
+++ b/frontend/src/api/models/VendingStatus.ts
@@ -1,0 +1,18 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ *
+ * The status object says whether the user is capable of receiving payments,
+ * and also whether or not there are pending onboarding operations to complete
+ *
+ */
+export type VendingStatus = {
+    status: string;
+    can_take_payments: boolean;
+    needs_attention: boolean;
+    details_submitted: boolean;
+};
+

--- a/frontend/src/api/models/VerificationMethod.ts
+++ b/frontend/src/api/models/VerificationMethod.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export enum VerificationMethod {
+    NONE = 'none',
+    MANUAL = 'manual',
+    WEBSITE = 'website',
+    LOGIN_PROVIDER = 'login_provider',
+}

--- a/frontend/src/api/models/VerificationStatus.ts
+++ b/frontend/src/api/models/VerificationStatus.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { LoginProvider } from './LoginProvider';
+import type { VerificationMethod } from './VerificationMethod';
+
+export type VerificationStatus = {
+    verified: boolean;
+    timestamp: (string | null);
+    method: (VerificationMethod | null);
+    website: (string | null);
+    login_provider: (LoginProvider | null);
+    login_name: (string | null);
+    login_is_organization: (boolean | null);
+    detail: (string | null);
+};
+

--- a/frontend/src/api/models/WebsiteVerificationResult.ts
+++ b/frontend/src/api/models/WebsiteVerificationResult.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { ErrorDetail } from './ErrorDetail';
+
+export type WebsiteVerificationResult = {
+    verified: boolean;
+    detail: (ErrorDetail | null);
+    status_code: (number | null);
+};
+

--- a/frontend/src/api/models/WebsiteVerificationToken.ts
+++ b/frontend/src/api/models/WebsiteVerificationToken.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type WebsiteVerificationToken = {
+    domain: string;
+    token: string;
+};
+

--- a/frontend/src/api/services/DefaultService.ts
+++ b/frontend/src/api/services/DefaultService.ts
@@ -1,0 +1,2485 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { AvailableMethods } from '../models/AvailableMethods';
+import type { Body_get_download_token_purchases_generate_download_token_post } from '../models/Body_get_download_token_purchases_generate_download_token_post';
+import type { BuildNotificationRequest } from '../models/BuildNotificationRequest';
+import type { CardInfo } from '../models/CardInfo';
+import type { ConnectedAccountProvider } from '../models/ConnectedAccountProvider';
+import type { DevelopersResponse } from '../models/DevelopersResponse';
+import type { InviteStatus } from '../models/InviteStatus';
+import type { LinkResponse } from '../models/LinkResponse';
+import type { MainCategory } from '../models/MainCategory';
+import type { ModerationApp } from '../models/ModerationApp';
+import type { ModerationAppsResponse } from '../models/ModerationAppsResponse';
+import type { NascentTransaction } from '../models/NascentTransaction';
+import type { OauthLoginResponseFailure } from '../models/OauthLoginResponseFailure';
+import type { OauthLoginResponseSuccess } from '../models/OauthLoginResponseSuccess';
+import type { Platform } from '../models/Platform';
+import type { ProposedPayment } from '../models/ProposedPayment';
+import type { RedemptionResult } from '../models/RedemptionResult';
+import type { Review } from '../models/Review';
+import type { ReviewRequest } from '../models/ReviewRequest';
+import type { ReviewRequestResponse } from '../models/ReviewRequestResponse';
+import type { SearchQuery } from '../models/SearchQuery';
+import type { StorefrontInfo } from '../models/StorefrontInfo';
+import type { TokenCancellation } from '../models/TokenCancellation';
+import type { TokenList } from '../models/TokenList';
+import type { TokenModel } from '../models/TokenModel';
+import type { Transaction } from '../models/Transaction';
+import type { TransactionSaveCard } from '../models/TransactionSaveCard';
+import type { TransactionSortOrder } from '../models/TransactionSortOrder';
+import type { UpsertQualityModeration } from '../models/UpsertQualityModeration';
+import type { UserDeleteRequest } from '../models/UserDeleteRequest';
+import type { VendingApplicationInformation } from '../models/VendingApplicationInformation';
+import type { VendingConfig } from '../models/VendingConfig';
+import type { VendingOnboardingRequest } from '../models/VendingOnboardingRequest';
+import type { VendingOutput } from '../models/VendingOutput';
+import type { VendingRedirect } from '../models/VendingRedirect';
+import type { VendingSetup } from '../models/VendingSetup';
+import type { VendingStatus } from '../models/VendingStatus';
+import type { VerificationStatus } from '../models/VerificationStatus';
+import type { WebsiteVerificationResult } from '../models/WebsiteVerificationResult';
+import type { WebsiteVerificationToken } from '../models/WebsiteVerificationToken';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+
+export class DefaultService {
+
+    /**
+     * Build Notification
+     * @param requestBody
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static buildNotificationEmailsBuildNotificationPost(
+        requestBody: BuildNotificationRequest,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/emails/build-notification',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Preview Templates
+     * @returns string Successful Response
+     * @throws ApiError
+     */
+    public static previewTemplatesEmailsPreviewGet(): CancelablePromise<string> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/emails/preview',
+        });
+    }
+
+    /**
+     * Preview Template
+     * @param name
+     * @returns string Successful Response
+     * @throws ApiError
+     */
+    public static previewTemplateEmailsPreviewNameGet(
+        name: string,
+    ): CancelablePromise<string> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/emails/preview/{name}',
+            path: {
+                'name': name,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+
+    /**
+     * Start Github Flow
+     * Starts a github login flow.  This will set session cookie values and
+     * will return a redirect.  The frontend is expected to save the cookie
+     * for use later, and follow the redirect to Github
+     *
+     * Upon return from Github to the frontend, the frontend should POST to this
+     * endpoint with the relevant data from Github
+     *
+     * If the user is already logged in, and has a valid github token stored,
+     * then this will return an error instead.
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static startGithubFlowAuthLoginGithubGet(): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/auth/login/github',
+        });
+    }
+
+    /**
+     * Continue Github Flow
+     * Process the result of the Github oauth flow
+     *
+     * This expects to have some JSON posted to it which (on success) contains:
+     *
+     * ```
+     * {
+         * "state": "the state code",
+         * "code": "the github oauth code",
+         * }
+         * ```
+         *
+         * On failure, the frontend should pass through the state and error so that
+         * the backend can clear the flow tokens
+         *
+         * ```
+         * {
+             * "state": "the state code",
+             * "error": "the error code returned from github",
+             * }
+             * ```
+             *
+             * This endpoint will either return an error, if something was wrong in the
+             * backend state machines; or it will return a success code with an indication
+             * of whether or not the login sequence completed OK.
+             * @param requestBody
+             * @returns any Successful Response
+             * @throws ApiError
+             */
+            public static continueGithubFlowAuthLoginGithubPost(
+                requestBody: (OauthLoginResponseSuccess | OauthLoginResponseFailure),
+            ): CancelablePromise<any> {
+                return __request(OpenAPI, {
+                    method: 'POST',
+                    url: '/auth/login/github',
+                    body: requestBody,
+                    mediaType: 'application/json',
+                    errors: {
+                        422: `Validation Error`,
+                    },
+                });
+            }
+
+            /**
+             * Start Gitlab Flow
+             * Starts a gitlab login flow.  This will set session cookie values and
+             * will return a redirect.  The frontend is expected to save the cookie
+             * for use later, and follow the redirect to Gitlab
+             *
+             * Upon return from Gitlab to the frontend, the frontend should POST to this
+             * endpoint with the relevant data from Gitlab
+             *
+             * If the user is already logged in, and has a valid gitlab token stored,
+             * then this will return an error instead.
+             * @returns any Successful Response
+             * @throws ApiError
+             */
+            public static startGitlabFlowAuthLoginGitlabGet(): CancelablePromise<any> {
+                return __request(OpenAPI, {
+                    method: 'GET',
+                    url: '/auth/login/gitlab',
+                });
+            }
+
+            /**
+             * Continue Gitlab Flow
+             * Process the result of the Gitlab oauth flow
+             *
+             * This expects to have some JSON posted to it which (on success) contains:
+             *
+             * ```
+             * {
+                 * "state": "the state code",
+                 * "code": "the gitlab oauth code",
+                 * }
+                 * ```
+                 *
+                 * On failure, the frontend should pass through the state and error so that
+                 * the backend can clear the flow tokens
+                 *
+                 * ```
+                 * {
+                     * "state": "the state code",
+                     * "error": "the error code returned from gitlab",
+                     * }
+                     * ```
+                     *
+                     * This endpoint will either return an error, if something was wrong in the
+                     * backend state machines; or it will return a success code with an indication
+                     * of whether or not the login sequence completed OK.
+                     * @param requestBody
+                     * @returns any Successful Response
+                     * @throws ApiError
+                     */
+                    public static continueGitlabFlowAuthLoginGitlabPost(
+                        requestBody: (OauthLoginResponseSuccess | OauthLoginResponseFailure),
+                    ): CancelablePromise<any> {
+                        return __request(OpenAPI, {
+                            method: 'POST',
+                            url: '/auth/login/gitlab',
+                            body: requestBody,
+                            mediaType: 'application/json',
+                            errors: {
+                                422: `Validation Error`,
+                            },
+                        });
+                    }
+
+                    /**
+                     * Start Gnome Flow
+                     * Starts a GNOME login flow.  This will set session cookie values and
+                     * will return a redirect.  The frontend is expected to save the cookie
+                     * for use later, and follow the redirect to GNOME Gitlab
+                     *
+                     * Upon return from GNOME to the frontend, the frontend should POST to this
+                     * endpoint with the relevant data from GNOME Gitlab
+                     *
+                     * If the user is already logged in, and has a valid GNOME Gitlab token stored,
+                     * then this will return an error instead.
+                     * @returns any Successful Response
+                     * @throws ApiError
+                     */
+                    public static startGnomeFlowAuthLoginGnomeGet(): CancelablePromise<any> {
+                        return __request(OpenAPI, {
+                            method: 'GET',
+                            url: '/auth/login/gnome',
+                        });
+                    }
+
+                    /**
+                     * Continue Gnome Flow
+                     * Process the result of the GNOME oauth flow
+                     *
+                     * This expects to have some JSON posted to it which (on success) contains:
+                     *
+                     * ```
+                     * {
+                         * "state": "the state code",
+                         * "code": "the gitlab oauth code",
+                         * }
+                         * ```
+                         *
+                         * On failure, the frontend should pass through the state and error so that
+                         * the backend can clear the flow tokens
+                         *
+                         * ```
+                         * {
+                             * "state": "the state code",
+                             * "error": "the error code returned from GNOME gitlab",
+                             * }
+                             * ```
+                             *
+                             * This endpoint will either return an error, if something was wrong in the
+                             * backend state machines; or it will return a success code with an indication
+                             * of whether or not the login sequence completed OK.
+                             * @param requestBody
+                             * @returns any Successful Response
+                             * @throws ApiError
+                             */
+                            public static continueGnomeFlowAuthLoginGnomePost(
+                                requestBody: (OauthLoginResponseSuccess | OauthLoginResponseFailure),
+                            ): CancelablePromise<any> {
+                                return __request(OpenAPI, {
+                                    method: 'POST',
+                                    url: '/auth/login/gnome',
+                                    body: requestBody,
+                                    mediaType: 'application/json',
+                                    errors: {
+                                        422: `Validation Error`,
+                                    },
+                                });
+                            }
+
+                            /**
+                             * Start Kde Flow
+                             * @returns any Successful Response
+                             * @throws ApiError
+                             */
+                            public static startKdeFlowAuthLoginKdeGet(): CancelablePromise<any> {
+                                return __request(OpenAPI, {
+                                    method: 'GET',
+                                    url: '/auth/login/kde',
+                                });
+                            }
+
+                            /**
+                             * Continue Kde Flow
+                             * @param requestBody
+                             * @returns any Successful Response
+                             * @throws ApiError
+                             */
+                            public static continueKdeFlowAuthLoginKdePost(
+                                requestBody: (OauthLoginResponseSuccess | OauthLoginResponseFailure),
+                            ): CancelablePromise<any> {
+                                return __request(OpenAPI, {
+                                    method: 'POST',
+                                    url: '/auth/login/kde',
+                                    body: requestBody,
+                                    mediaType: 'application/json',
+                                    errors: {
+                                        422: `Validation Error`,
+                                    },
+                                });
+                            }
+
+                            /**
+                             * Continue Google Flow
+                             * Process the result of the Google oauth flow
+                             *
+                             * This expects to have some JSON posted to it which (on success) contains:
+                             *
+                             * ```
+                             * {
+                                 * "state": "the state code",
+                                 * "code": "the google oauth code",
+                                 * }
+                                 * ```
+                                 *
+                                 * On failure, the frontend should pass through the state and error so that
+                                 * the backend can clear the flow tokens
+                                 *
+                                 * ```
+                                 * {
+                                     * "state": "the state code",
+                                     * "error": "the error code returned from google",
+                                     * }
+                                     * ```
+                                     *
+                                     * This endpoint will either return an error, if something was wrong in the
+                                     * backend state machines; or it will return a success code with an indication
+                                     * of whether or not the login sequence completed OK.
+                                     * @param requestBody
+                                     * @returns any Successful Response
+                                     * @throws ApiError
+                                     */
+                                    public static continueGoogleFlowAuthLoginGooglePost(
+                                        requestBody: (OauthLoginResponseSuccess | OauthLoginResponseFailure),
+                                    ): CancelablePromise<any> {
+                                        return __request(OpenAPI, {
+                                            method: 'POST',
+                                            url: '/auth/login/google',
+                                            body: requestBody,
+                                            mediaType: 'application/json',
+                                            errors: {
+                                                422: `Validation Error`,
+                                            },
+                                        });
+                                    }
+
+                                    /**
+                                     * Get Userinfo
+                                     * Retrieve the current login's user information.  If the user is not logged in
+                                     * you will get a `204` return.  Otherwise you will receive JSON describing the
+                                     * currently logged in user, for example:
+                                     *
+                                     * ```
+                                     * {
+                                         * "displayname": "Mx Human Person",
+                                         * "dev-flatpaks": [ "org.people.human.Appname" ],
+                                         * "owned-flatpaks": [ "org.foo.bar.Appname" ],
+                                         * "accepted-publisher-agreement-at": "2023-06-23T20:38:28.553028"
+                                         * }
+                                         * ```
+                                         *
+                                         * If the user has an active github login, you'll also get their github login
+                                         * name, and avatar.  If they have some other login, details for that login
+                                         * will be provided.
+                                         *
+                                         * dev-flatpaks is filtered against IDs available in AppStream
+                                         * @returns any Successful Response
+                                         * @throws ApiError
+                                         */
+                                        public static getUserinfoAuthUserinfoGet(): CancelablePromise<any> {
+                                            return __request(OpenAPI, {
+                                                method: 'GET',
+                                                url: '/auth/userinfo',
+                                            });
+                                        }
+
+                                        /**
+                                         * Do Refresh Dev Flatpaks
+                                         * @returns any Successful Response
+                                         * @throws ApiError
+                                         */
+                                        public static doRefreshDevFlatpaksAuthRefreshDevFlatpaksPost(): CancelablePromise<any> {
+                                            return __request(OpenAPI, {
+                                                method: 'POST',
+                                                url: '/auth/refresh-dev-flatpaks',
+                                            });
+                                        }
+
+                                        /**
+                                         * Do Logout
+                                         * Clear the login state.  This will discard tokens which access socials,
+                                         * and will clear the session cookie so that the user is not logged in.
+                                         * @returns any Successful Response
+                                         * @throws ApiError
+                                         */
+                                        public static doLogoutAuthLogoutPost(): CancelablePromise<any> {
+                                            return __request(OpenAPI, {
+                                                method: 'POST',
+                                                url: '/auth/logout',
+                                            });
+                                        }
+
+                                        /**
+                                         * Get Deleteuser
+                                         * Delete a user's login information.
+                                         * If they're not logged in, they'll get a `403` return.
+                                         * Otherwise they will get an option to delete their account
+                                         * and data.
+                                         * @returns any Successful Response
+                                         * @throws ApiError
+                                         */
+                                        public static getDeleteuserAuthDeleteuserGet(): CancelablePromise<any> {
+                                            return __request(OpenAPI, {
+                                                method: 'GET',
+                                                url: '/auth/deleteuser',
+                                            });
+                                        }
+
+                                        /**
+                                         * Do Deleteuser
+                                         * Clear the login state. This will then delete the user's account
+                                         * and associated data. Unless there is an error.
+                                         *
+                                         * The input to this should be of the form:
+                                         *
+                                         * ```json
+                                         * {
+                                             * "token": "...",
+                                             * }
+                                             * ```
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static doDeleteuserAuthDeleteuserPost(
+                                                requestBody: UserDeleteRequest,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/auth/deleteuser',
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Do Agree To Publisher Agreement
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static doAgreeToPublisherAgreementAuthAcceptPublisherAgreementPost(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/auth/accept-publisher-agreement',
+                                                });
+                                            }
+
+                                            /**
+                                             * Do Change Default Account
+                                             * Changes the user's default account, which determines which display name and email we use.
+                                             * @param provider
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static doChangeDefaultAccountAuthChangeDefaultAccountPost(
+                                                provider: ConnectedAccountProvider,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/auth/change-default-account',
+                                                    query: {
+                                                        'provider': provider,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Moderation Apps
+                                             * Get a list of apps with unhandled moderation requests.
+                                             * @param newSubmissions
+                                             * @param limit
+                                             * @param offset
+                                             * @returns ModerationAppsResponse Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getModerationAppsModerationAppsGet(
+                                                newSubmissions?: (boolean | null),
+                                                limit: number = 100,
+                                                offset?: number,
+                                            ): CancelablePromise<ModerationAppsResponse> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/moderation/apps',
+                                                    query: {
+                                                        'new_submissions': newSubmissions,
+                                                        'limit': limit,
+                                                        'offset': offset,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Moderation App
+                                             * Get a list of moderation requests for an app.
+                                             * @param appId
+                                             * @param includeOutdated
+                                             * @param includeHandled
+                                             * @param limit
+                                             * @param offset
+                                             * @returns ModerationApp Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getModerationAppModerationAppsAppIdGet(
+                                                appId: string,
+                                                includeOutdated: boolean = false,
+                                                includeHandled: boolean = false,
+                                                limit: number = 100,
+                                                offset?: number,
+                                            ): CancelablePromise<ModerationApp> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/moderation/apps/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'include_outdated': includeOutdated,
+                                                        'include_handled': includeHandled,
+                                                        'limit': limit,
+                                                        'offset': offset,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Submit Review Request
+                                             * @param requestBody
+                                             * @returns ReviewRequestResponse Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static submitReviewRequestModerationSubmitReviewRequestPost(
+                                                requestBody: ReviewRequest,
+                                            ): CancelablePromise<ReviewRequestResponse> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/moderation/submit_review_request',
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Submit Review
+                                             * Approve or reject the moderation request with a comment. If all requests for a job are approved, the job is
+                                             * marked as successful in flat-manager.
+                                             * @param id
+                                             * @param requestBody
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static submitReviewModerationRequestsIdReviewPost(
+                                                id: number,
+                                                requestBody: Review,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/moderation/requests/{id}/review',
+                                                    path: {
+                                                        'id': id,
+                                                    },
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Walletinfo
+                                             * Retrieve the wallet for the currently logged in user.
+                                             *
+                                             * This will return a list of cards which the user has saved to their account.
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getWalletinfoWalletWalletinfoGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/wallet/walletinfo',
+                                                });
+                                            }
+
+                                            /**
+                                             * Post Removecard
+                                             * Remove a card from a user's wallet.
+                                             *
+                                             * The provided information must exactly match a card as would be returned from the
+                                             * wallet info endpoint.
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static postRemovecardWalletRemovecardPost(
+                                                requestBody: CardInfo,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/wallet/removecard',
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Transactions
+                                             * Return a list of transactions associated with this user.
+                                             *
+                                             * If anything goes wrong, an error will be returned, otherwise a list of transaction
+                                             * summaries will be returned.
+                                             * @param sort
+                                             * @param since
+                                             * @param limit
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getTransactionsWalletTransactionsGet(
+                                                sort?: TransactionSortOrder,
+                                                since?: (string | null),
+                                                limit: number = 100,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/wallet/transactions',
+                                                    query: {
+                                                        'sort': sort,
+                                                        'since': since,
+                                                        'limit': limit,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Create Transaction
+                                             * Create a new transaction, return the ID.
+                                             *
+                                             * If the passed in nascent transaction is valid, this will create a transaction and
+                                             * return the ID of the newly created wallet, otherwise it'll return an error
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static createTransactionWalletTransactionsPost(
+                                                requestBody: NascentTransaction,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/wallet/transactions',
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Transaction By Id
+                                             * Retrieve a transaction by its ID
+                                             *
+                                             * If the transaction ID is valid, and owned by the calling user, then this will
+                                             * retrieve the whole transaction, including card details and disbursement information
+                                             * if available.
+                                             * @param txn
+                                             * @returns Transaction Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getTransactionByIdWalletTransactionsTxnGet(
+                                                txn: string,
+                                            ): CancelablePromise<Transaction> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/wallet/transactions/{txn}',
+                                                    path: {
+                                                        'txn': txn,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Set Transaction Card
+                                             * Set the card associated with a transaction.
+                                             *
+                                             * The posted card must exactly match one of the cards returned by the wallet
+                                             * info endpoint or else the update may not succeed
+                                             * @param txn
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static setTransactionCardWalletTransactionsTxnSetcardPost(
+                                                txn: string,
+                                                requestBody: CardInfo,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/wallet/transactions/{txn}/setcard',
+                                                    path: {
+                                                        'txn': txn,
+                                                    },
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Cancel Transaction
+                                             * Cancel a transaction in the `new` or `retry` states.
+                                             *
+                                             * Note that this may actually not cancel if a webhook fires asynchronously
+                                             * and updates the transaction.  This API will not attempt to prevent stripe
+                                             * payments from completing.
+                                             * @param txn
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static cancelTransactionWalletTransactionsTxnCancelPost(
+                                                txn: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/wallet/transactions/{txn}/cancel',
+                                                    path: {
+                                                        'txn': txn,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Stripedata
+                                             * Return the stripe public key to use in the frontend.  Since this is not
+                                             * considered secret, we don't need a login or anything for this
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getStripedataWalletStripedataGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/wallet/stripedata',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Txn Stripedata
+                                             * Return the Stripe data associated with the given transaction.
+                                             *
+                                             * This is only applicable to transactions in the `new` or `retry` state and
+                                             * will only work for transactions which *are* Stripe transactions.
+                                             * @param txn
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getTxnStripedataWalletTransactionsTxnStripeGet(
+                                                txn: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/wallet/transactions/{txn}/stripe',
+                                                    path: {
+                                                        'txn': txn,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Set Savecard
+                                             * Set the save-card status.
+                                             *
+                                             * This is only applicable to transactions in the `new` or `retry` state
+                                             * and will only work for transactions which are backed by stripe or similar.
+                                             *
+                                             * If the `save_card` parameter is null, then the card will not be saved,
+                                             * otherwise it will be saved.  If it's set to `off_session` then an attempt
+                                             * will be made to create a saved method which can be used without the user
+                                             * re-authenticating
+                                             * @param txn
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static setSavecardWalletTransactionsTxnSavecardPost(
+                                                txn: string,
+                                                requestBody: TransactionSaveCard,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/wallet/transactions/{txn}/savecard',
+                                                    path: {
+                                                        'txn': txn,
+                                                    },
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Set Pending
+                                             * Set the transaction as 'pending' so that we can recover if Stripe
+                                             * flows don't quite work (e.g. webhook goes missing)
+                                             * @param txn
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static setPendingWalletTransactionsTxnSetpendingPost(
+                                                txn: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/wallet/transactions/{txn}/setpending',
+                                                    path: {
+                                                        'txn': txn,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Webhook
+                                             * This endpoint is intended to deal with webhooks coming back from payment
+                                             * mechanisms etc.  It exists only for the deployed wallet, so its name
+                                             * will vary with the deployed wallet kind.
+                                             *
+                                             * The exact form of the content posted to the webhook will vary from wallet
+                                             * kind to wallet kind.
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static webhookWalletWebhookStripePost(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/wallet/webhook/stripe',
+                                                });
+                                            }
+
+                                            /**
+                                             * Status
+                                             * Retrieve the vending status of the logged in user.
+                                             *
+                                             * This will return `201` if the logged in user has never begun the onboarding
+                                             * flow to be a vendor on Flathub.
+                                             * @returns VendingStatus Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static statusVendingStatusGet(): CancelablePromise<VendingStatus> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/vending/status',
+                                                });
+                                            }
+
+                                            /**
+                                             * Start Onboarding
+                                             * Start or continue the onboarding process.
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static startOnboardingVendingStatusOnboardingPost(
+                                                requestBody: VendingOnboardingRequest,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/vending/status/onboarding',
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Dashboard Link
+                                             * Retrieve a link to the logged in user's Stripe express dashboard.
+                                             *
+                                             * The user must be logged in and must have onboarded.
+                                             * @returns VendingRedirect Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getDashboardLinkVendingStatusDashboardlinkGet(): CancelablePromise<VendingRedirect> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/vending/status/dashboardlink',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Global Vending Config
+                                             * Retrieve the configuration values needed to calculate application
+                                             * vending splits client-side.
+                                             *
+                                             * Configuration includes:
+                                             * - Fee values
+                                             * - Platform values
+                                             * @returns VendingConfig Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getGlobalVendingConfigVendingConfigGet(): CancelablePromise<VendingConfig> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/vending/config',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get App Vending Setup
+                                             * Retrieve the vending status for a given application.  Returns a no
+                                             * content response if the appid has no vending setup.
+                                             * @param appId
+                                             * @returns VendingSetup Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getAppVendingSetupVendingappAppIdSetupGet(
+                                                appId: string,
+                                            ): CancelablePromise<VendingSetup> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/vendingapp/{app_id}/setup',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Post App Vending Setup
+                                             * Create/update the vending status for a given application.  Returns an error
+                                             * if the appid is not known, or if it's already set up for vending with a
+                                             * user other than the one calling this API.
+                                             *
+                                             * If you do not have the right to set the vending status for this application
+                                             * then you will also be refused.
+                                             *
+                                             * In addition, if any of the currency or amount values constraints are violated
+                                             * then you will get an error
+                                             * @param appId
+                                             * @param requestBody
+                                             * @returns VendingSetup Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static postAppVendingSetupVendingappAppIdSetupPost(
+                                                appId: string,
+                                                requestBody: VendingSetup,
+                                            ): CancelablePromise<VendingSetup> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/vendingapp/{app_id}/setup',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Post App Vending Status
+                                             * Construct a transaction for the given application with the proposed payment.
+                                             * If the proposed payment is unacceptable then an error will be returned.
+                                             * If the user is not logged in, then an error will be returned.
+                                             *
+                                             * Otherwise a transaction will be created and the information about it will be
+                                             * returned in the output of the call.
+                                             * @param appId
+                                             * @param requestBody
+                                             * @returns VendingOutput Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static postAppVendingStatusVendingappAppIdPost(
+                                                appId: string,
+                                                requestBody: ProposedPayment,
+                                            ): CancelablePromise<VendingOutput> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/vendingapp/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Redeemable Tokens
+                                             * Retrieve the redeemable tokens for the given application.
+                                             *
+                                             * The caller must have control of the app at some level
+                                             *
+                                             * For now, there is no pagination or filtering, all tokens will be returned
+                                             * @param appId
+                                             * @returns TokenList Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRedeemableTokensVendingappAppIdTokensGet(
+                                                appId: string,
+                                            ): CancelablePromise<TokenList> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/vendingapp/{app_id}/tokens',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Create Tokens
+                                             * Create some tokens for the given appid.
+                                             *
+                                             * The calling user must own the vending config for this application
+                                             * @param appId
+                                             * @param requestBody
+                                             * @returns TokenModel Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static createTokensVendingappAppIdTokensPost(
+                                                appId: string,
+                                                requestBody: Array<string>,
+                                            ): CancelablePromise<Array<TokenModel>> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/vendingapp/{app_id}/tokens',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Cancel Tokens
+                                             * Cancel a set of tokens
+                                             * @param appId
+                                             * @param requestBody
+                                             * @returns TokenCancellation Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static cancelTokensVendingappAppIdTokensCancelPost(
+                                                appId: string,
+                                                requestBody: Array<string>,
+                                            ): CancelablePromise<Array<TokenCancellation>> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/vendingapp/{app_id}/tokens/cancel',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Redeem Token
+                                             * This redeems the given token for the logged in user.
+                                             *
+                                             * If the logged in user already owns the app then the token will not be redeemed
+                                             * @param appId
+                                             * @param token
+                                             * @returns RedemptionResult Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static redeemTokenVendingappAppIdTokensRedeemTokenPost(
+                                                appId: string,
+                                                token: string,
+                                            ): CancelablePromise<RedemptionResult> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/vendingapp/{app_id}/tokens/redeem/{token}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                        'token': token,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * App Info
+                                             * This determines the vending info for the app and returns it
+                                             * @param appId
+                                             * @returns VendingApplicationInformation Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static appInfoVendingappAppIdInfoGet(
+                                                appId: string,
+                                            ): CancelablePromise<VendingApplicationInformation> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/vendingapp/{app_id}/info',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Verification Status
+                                             * Gets the verification status of the given app.
+                                             * @param appId
+                                             * @returns VerificationStatus Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getVerificationStatusVerificationAppIdStatusGet(
+                                                appId: string,
+                                            ): CancelablePromise<VerificationStatus> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/verification/{app_id}/status',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Available Methods
+                                             * Gets the ways an app may be verified.
+                                             * @param appId
+                                             * @param newApp
+                                             * @returns AvailableMethods Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getAvailableMethodsVerificationAppIdAvailableMethodsGet(
+                                                appId: string,
+                                                newApp: boolean = false,
+                                            ): CancelablePromise<AvailableMethods> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/verification/{app_id}/available-methods',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'new_app': newApp,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Verify By Login Provider
+                                             * If the current account is eligible to verify the given account via SSO, and the app is not already verified by
+                                             * someone else, marks the app as verified.
+                                             * @param appId
+                                             * @param newApp
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static verifyByLoginProviderVerificationAppIdVerifyByLoginProviderPost(
+                                                appId: string,
+                                                newApp: boolean = false,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/verification/{app_id}/verify-by-login-provider',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'new_app': newApp,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Request Organization Access Github
+                                             * Returns the URL to request access to the organization so we can verify the user's membership.
+                                             * @returns LinkResponse Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static requestOrganizationAccessGithubVerificationRequestOrganizationAccessGithubGet(): CancelablePromise<LinkResponse> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/verification/request-organization-access/github',
+                                                });
+                                            }
+
+                                            /**
+                                             * Setup Website Verification
+                                             * Creates a token for the user to verify the app via website.
+                                             * @param appId
+                                             * @param newApp
+                                             * @returns WebsiteVerificationToken Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static setupWebsiteVerificationVerificationAppIdSetupWebsiteVerificationPost(
+                                                appId: string,
+                                                newApp: boolean = false,
+                                            ): CancelablePromise<WebsiteVerificationToken> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/verification/{app_id}/setup-website-verification',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'new_app': newApp,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Confirm Website Verification
+                                             * Checks website verification, and if it succeeds, marks the app as verified for the current account.
+                                             * @param appId
+                                             * @param newApp
+                                             * @returns WebsiteVerificationResult Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static confirmWebsiteVerificationVerificationAppIdConfirmWebsiteVerificationPost(
+                                                appId: string,
+                                                newApp: boolean = false,
+                                            ): CancelablePromise<WebsiteVerificationResult> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/verification/{app_id}/confirm-website-verification',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'new_app': newApp,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Unverify
+                                             * If the current account has verified the given app, mark it as no longer verified.
+                                             * @param appId
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static unverifyVerificationAppIdUnverifyPost(
+                                                appId: string,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/verification/{app_id}/unverify',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Storefront Info
+                                             * This endpoint is used by the flathub-hooks scripts to get information about an app to insert into the appstream
+                                             * file and commit metadata.
+                                             * @param appId
+                                             * @returns StorefrontInfo Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getStorefrontInfoPurchasesStorefrontInfoGet(
+                                                appId: string,
+                                            ): CancelablePromise<StorefrontInfo> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/purchases/storefront-info',
+                                                    query: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Is Free Software
+                                             * Gets whether the app is Free Software based on the app ID and license, even if the app is not in the appstream
+                                             * database yet. This is needed in flat-manager-hooks to run validations the first time an app is uploaded.
+                                             * @param appId
+                                             * @param license
+                                             * @returns boolean Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getIsFreeSoftwarePurchasesStorefrontInfoIsFreeSoftwareGet(
+                                                appId: string,
+                                                license?: (string | null),
+                                            ): CancelablePromise<boolean> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/purchases/storefront-info/is-free-software',
+                                                    query: {
+                                                        'app_id': appId,
+                                                        'license': license,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Update Token
+                                             * Generates an update token for a user account. This token allows the user to generate download tokens for apps they
+                                             * already own, but does not grant permission to do anything else. By storing this token, flathub-authenticator is
+                                             * able to update apps without user interaction.
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getUpdateTokenPurchasesGenerateUpdateTokenPost(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/purchases/generate-update-token',
+                                                });
+                                            }
+
+                                            /**
+                                             * Check Purchases
+                                             * Checks whether the logged in user is able to download all of the given app refs.
+                                             *
+                                             * App IDs can be in the form of full refs, e.g. "app/org.gnome.Maps/x86_64/stable", or just the app ID, e.g.
+                                             * "org.gnome.Maps".
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static checkPurchasesPurchasesCheckPurchasesPost(
+                                                requestBody: Array<string>,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/purchases/check-purchases',
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Download Token
+                                             * Generates a download token for the given app IDs. App IDs should be in the form of full refs, e.g.
+                                             * "app/org.gnome.Maps/x86_64/stable".
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getDownloadTokenPurchasesGenerateDownloadTokenPost(
+                                                requestBody: Body_get_download_token_purchases_generate_download_token_post,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/purchases/generate-download-token',
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Invite Status
+                                             * @param appId
+                                             * @returns InviteStatus Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getInviteStatusInvitesAppIdGet(
+                                                appId: string,
+                                            ): CancelablePromise<InviteStatus> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/invites/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Invite Developer
+                                             * @param appId
+                                             * @param inviteCode
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static inviteDeveloperInvitesAppIdInvitePost(
+                                                appId: string,
+                                                inviteCode: string,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/invites/{app_id}/invite',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'invite_code': inviteCode,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Accept Invite
+                                             * @param appId
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static acceptInviteInvitesAppIdAcceptPost(
+                                                appId: string,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/invites/{app_id}/accept',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Decline Invite
+                                             * @param appId
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static declineInviteInvitesAppIdDeclinePost(
+                                                appId: string,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/invites/{app_id}/decline',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Leave Team
+                                             * @param appId
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static leaveTeamInvitesAppIdLeavePost(
+                                                appId: string,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/invites/{app_id}/leave',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Developers
+                                             * @param appId
+                                             * @returns DevelopersResponse Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getDevelopersInvitesAppIdDevelopersGet(
+                                                appId: string,
+                                            ): CancelablePromise<DevelopersResponse> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/invites/{app_id}/developers',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Remove Developer
+                                             * @param appId
+                                             * @param developerId
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static removeDeveloperInvitesAppIdRemoveDeveloperPost(
+                                                appId: string,
+                                                developerId: number,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/invites/{app_id}/remove-developer',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'developer_id': developerId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Revoke Invite
+                                             * @param appId
+                                             * @param inviteId
+                                             * @returns void
+                                             * @throws ApiError
+                                             */
+                                            public static revokeInviteInvitesAppIdRevokePost(
+                                                appId: string,
+                                                inviteId: number,
+                                            ): CancelablePromise<void> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/invites/{app_id}/revoke',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'invite_id': inviteId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Apps
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getAppsCompatAppsGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Apps In Category
+                                             * @param category
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getAppsInCategoryCompatAppsCategoryCategoryGet(
+                                                category: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/category/{category}',
+                                                    path: {
+                                                        'category': category,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Recently Updated
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRecentlyUpdatedCompatAppsCollectionRecentlyUpdated50Get(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/collection/recently-updated/50',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Recently Updated
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRecentlyUpdatedCompatAppsCollectionRecentlyUpdatedGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/collection/recently-updated',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Recently Added
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRecentlyAddedCompatAppsCollectionNew50Get(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/collection/new/50',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Recently Added
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRecentlyAddedCompatAppsCollectionNewGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/collection/new',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Popular Apps
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getPopularAppsCompatAppsCollectionPopular50Get(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/collection/popular/50',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Popular Apps
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getPopularAppsCompatAppsCollectionPopularGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/collection/popular',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Search
+                                             * @param query
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getSearchCompatAppsSearchQueryGet(
+                                                query: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/search/{query}',
+                                                    path: {
+                                                        'query': query,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Single App
+                                             * @param appId
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getSingleAppCompatAppsAppIdGet(
+                                                appId: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/compat/apps/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Quality Moderation Status
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getQualityModerationStatusQualityModerationStatusGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/quality-moderation/status',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Quality Moderation For App
+                                             * @param appId
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getQualityModerationForAppQualityModerationAppIdGet(
+                                                appId: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/quality-moderation/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Set Quality Moderation For App
+                                             * @param appId
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static setQualityModerationForAppQualityModerationAppIdPost(
+                                                appId: string,
+                                                requestBody: UpsertQualityModeration,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/quality-moderation/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Quality Moderation Status For App
+                                             * @param appId
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getQualityModerationStatusForAppQualityModerationAppIdStatusGet(
+                                                appId: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/quality-moderation/{app_id}/status',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Update
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static updateUpdatePost(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/update',
+                                                });
+                                            }
+
+                                            /**
+                                             * Update Stats
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static updateStatsUpdateStatsPost(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/update/stats',
+                                                });
+                                            }
+
+                                            /**
+                                             * Process Transfers
+                                             * Process any pending transfers which may be in the system
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static processTransfersUpdateProcessPendingTransfersPost(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/update/process-pending-transfers',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Categories
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getCategoriesCategoriesGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/categories',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Category
+                                             * @param category
+                                             * @param page
+                                             * @param perPage
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getCategoryCategoryCategoryGet(
+                                                category: MainCategory,
+                                                page?: (number | null),
+                                                perPage?: (number | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/category/{category}',
+                                                    path: {
+                                                        'category': category,
+                                                    },
+                                                    query: {
+                                                        'page': page,
+                                                        'per_page': perPage,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Subcategory
+                                             * @param category
+                                             * @param subcategory
+                                             * @param page
+                                             * @param perPage
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getSubcategoryCategoryCategorySubcategoriesSubcategoryGet(
+                                                category: MainCategory,
+                                                subcategory: string,
+                                                page?: (number | null),
+                                                perPage?: (number | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/category/{category}/subcategories/{subcategory}',
+                                                    path: {
+                                                        'category': category,
+                                                        'subcategory': subcategory,
+                                                    },
+                                                    query: {
+                                                        'page': page,
+                                                        'per_page': perPage,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Developers
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getDevelopersDeveloperGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/developer',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Developer
+                                             * @param developer
+                                             * @param page
+                                             * @param perPage
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getDeveloperDeveloperDeveloperGet(
+                                                developer: string,
+                                                page?: (number | null),
+                                                perPage?: (number | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/developer/{developer}',
+                                                    path: {
+                                                        'developer': developer,
+                                                    },
+                                                    query: {
+                                                        'page': page,
+                                                        'per_page': perPage,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Eol Rebase
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getEolRebaseEolRebaseGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/eol/rebase',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Eol Rebase Appid
+                                             * @param appId
+                                             * @param branch
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getEolRebaseAppidEolRebaseAppIdGet(
+                                                appId: string,
+                                                branch: string = 'stable',
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/eol/rebase/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'branch': branch,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Eol Message
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getEolMessageEolMessageGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/eol/message',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Eol Message Appid
+                                             * @param appId
+                                             * @param branch
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getEolMessageAppidEolMessageAppIdGet(
+                                                appId: string,
+                                                branch: string = 'stable',
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/eol/message/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'branch': branch,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Project Groups
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getProjectGroupsProjectgroupGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/projectgroup',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Project Group
+                                             * @param projectGroup
+                                             * @param page
+                                             * @param perPage
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getProjectGroupProjectgroupProjectGroupGet(
+                                                projectGroup: string,
+                                                page?: (number | null),
+                                                perPage?: (number | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/projectgroup/{project_group}',
+                                                    path: {
+                                                        'project_group': projectGroup,
+                                                    },
+                                                    query: {
+                                                        'page': page,
+                                                        'per_page': perPage,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * List Appstream
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static listAppstreamAppstreamGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/appstream',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Appstream
+                                             * @param appId
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getAppstreamAppstreamAppIdGet(
+                                                appId: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/appstream/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Post Search
+                                             * @param requestBody
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static postSearchSearchPost(
+                                                requestBody: SearchQuery,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'POST',
+                                                    url: '/search',
+                                                    body: requestBody,
+                                                    mediaType: 'application/json',
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Runtime List
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRuntimeListRuntimesGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/runtimes',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Recently Updated
+                                             * @param page
+                                             * @param perPage
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRecentlyUpdatedCollectionRecentlyUpdatedGet(
+                                                page?: (number | null),
+                                                perPage?: (number | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/collection/recently-updated',
+                                                    query: {
+                                                        'page': page,
+                                                        'per_page': perPage,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Recently Added
+                                             * @param page
+                                             * @param perPage
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRecentlyAddedCollectionRecentlyAddedGet(
+                                                page?: (number | null),
+                                                perPage?: (number | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/collection/recently-added',
+                                                    query: {
+                                                        'page': page,
+                                                        'per_page': perPage,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Verified
+                                             * @param page
+                                             * @param perPage
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getVerifiedCollectionVerifiedGet(
+                                                page?: (number | null),
+                                                perPage?: (number | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/collection/verified',
+                                                    query: {
+                                                        'page': page,
+                                                        'per_page': perPage,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Popular Last Month
+                                             * @param page
+                                             * @param perPage
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getPopularLastMonthPopularLastMonthGet(
+                                                page?: (number | null),
+                                                perPage?: (number | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/popular/last-month',
+                                                    query: {
+                                                        'page': page,
+                                                        'per_page': perPage,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Recently Updated Apps Feed
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getRecentlyUpdatedAppsFeedFeedRecentlyUpdatedGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/feed/recently-updated',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get New Apps Feed
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getNewAppsFeedFeedNewGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/feed/new',
+                                                });
+                                            }
+
+                                            /**
+                                             * Healthcheck
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static healthcheckStatusGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/status',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Stats
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getStatsStatsGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/stats',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Stats For App
+                                             * @param appId
+                                             * @param all
+                                             * @param days
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getStatsForAppStatsAppIdGet(
+                                                appId: string,
+                                                all: boolean = false,
+                                                days: number = 180,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/stats/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'all': all,
+                                                        'days': days,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Summary
+                                             * @param appId
+                                             * @param branch
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getSummarySummaryAppIdGet(
+                                                appId: string,
+                                                branch?: (string | null),
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/summary/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    query: {
+                                                        'branch': branch,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Platforms
+                                             * Return a mapping from org-name to platform aliases and dependencies which are
+                                             * recognised by the backend.  These are used by things such as the transactions
+                                             * and donations APIs to address amounts to the platforms.
+                                             * @returns Platform Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getPlatformsPlatformsGet(): CancelablePromise<Record<string, Platform>> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/platforms',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Exceptions
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getExceptionsExceptionsGet(): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/exceptions',
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Exceptions For App
+                                             * @param appId
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getExceptionsForAppExceptionsAppIdGet(
+                                                appId: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/exceptions/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                            /**
+                                             * Get Addons
+                                             * @param appId
+                                             * @returns any Successful Response
+                                             * @throws ApiError
+                                             */
+                                            public static getAddonsAddonAppIdGet(
+                                                appId: string,
+                                            ): CancelablePromise<any> {
+                                                return __request(OpenAPI, {
+                                                    method: 'GET',
+                                                    url: '/addon/{app_id}',
+                                                    path: {
+                                                        'app_id': appId,
+                                                    },
+                                                    errors: {
+                                                        422: `Validation Error`,
+                                                    },
+                                                });
+                                            }
+
+                                        }

--- a/frontend/src/api/services/LoginService.ts
+++ b/frontend/src/api/services/LoginService.ts
@@ -1,0 +1,33 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { LoginMethod } from '../models/LoginMethod';
+
+import type { CancelablePromise } from '../core/CancelablePromise';
+import { OpenAPI } from '../core/OpenAPI';
+import { request as __request } from '../core/request';
+
+export class LoginService {
+
+    /**
+     * Get Login Kinds
+     * Retrieve the login methods available from the backend.
+     *
+     * For each method returned, flow starts with a `GET` to the endpoint
+     * `.../login/{method}` and upon completion from the user-agent, with a `POST`
+     * to that same endpoint name.
+     *
+     * Each method is also given a button icon and some text to use, though
+     * frontends with localisation may choose to render other text instead.
+     * @returns LoginMethod Successful Response
+     * @throws ApiError
+     */
+    public static getLoginKindsAuthLoginGet(): CancelablePromise<Array<LoginMethod>> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/auth/login',
+        });
+    }
+
+}

--- a/frontend/src/components/application/AppVerificationControls/LoginVerification.tsx
+++ b/frontend/src/components/application/AppVerificationControls/LoginVerification.tsx
@@ -5,10 +5,8 @@ import Button from "src/components/Button"
 import ProviderLink from "src/components/login/ProviderLink"
 import { useUserContext } from "src/context/user-info"
 import InlineError from "src/components/InlineError"
-import {
-  fetchGithubRequestOrgAccessLink,
-  fetchLoginProviders,
-} from "src/fetchers"
+import { fetchGithubRequestOrgAccessLink } from "src/fetchers"
+import { LoginService } from "src/api"
 import { VerificationMethodLoginProvider } from "src/types/VerificationAvailableMethods"
 import { verificationProviderToHumanReadable } from "src/verificationProvider"
 import { FlathubDisclosure } from "../../Disclosure"
@@ -37,9 +35,7 @@ const LoginVerification: FunctionComponent<Props> = ({
 
   const { data: providers } = useQuery({
     queryKey: ["login-providers"],
-    queryFn: async () => {
-      return fetchLoginProviders()
-    },
+    queryFn: () => LoginService.getLoginKindsAuthLoginGet(),
   })
 
   const { data: githubOrgAccessLink } = useQuery({
@@ -195,7 +191,7 @@ const LoginVerification: FunctionComponent<Props> = ({
       break
 
     case "not_logged_in":
-      const provider = providers?.data.filter(
+      const provider = providers?.filter(
         (provider) => provider.method === method.login_provider,
       )[0]
 

--- a/frontend/src/fetchers.ts
+++ b/frontend/src/fetchers.ts
@@ -245,10 +245,6 @@ export async function fetchSearchQuery(
   )
 }
 
-export async function fetchLoginProviders() {
-  return axios.get<LoginProvider[]>(LOGIN_PROVIDERS_URL)
-}
-
 export async function fetchGithubRequestOrgAccessLink() {
   return axios.get<{ link: string }>(REQUEST_ORG_ACCESS_LINK_GITHUB)
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -20,6 +20,16 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@apidevtools/json-schema-ref-parser@9.0.9":
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz#d720f9256e3609621280584f2b47ae165359268b"
+  integrity sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.6"
+    call-me-maybe "^1.0.1"
+    js-yaml "^4.1.0"
+
 "@aw-web-design/x-default-browser@1.4.126":
   version "1.4.126"
   resolved "https://registry.yarnpkg.com/@aw-web-design/x-default-browser/-/x-default-browser-1.4.126.tgz#43e4bd8f0314ed907a8718d7e862a203af79bc16"
@@ -1802,6 +1812,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jsdevtools/ono@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
+  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
 "@juggle/resize-observer@^3.3.1":
   version "3.4.0"
@@ -3781,6 +3796,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/json-schema@^7.0.6":
+  version "7.0.13"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.13.tgz#02c24f4363176d2d18fc8b70b9f3c54aba178a85"
+  integrity sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz"
@@ -4905,6 +4925,11 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
+call-me-maybe@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz#03f964f19522ba643b1b0693acb9152fe2074baa"
+  integrity sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
@@ -4927,6 +4952,11 @@ camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelcase@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001517, caniuse-lite@^1.0.30001520:
   version "1.0.30001522"
@@ -5145,6 +5175,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.0.0.tgz#43e19c25dbedc8256203538e8d7e9346877a6f67"
+  integrity sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==
 
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
@@ -6761,7 +6796,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@11.1.1, fs-extra@^11.1.0:
+fs-extra@11.1.1, fs-extra@^11.1.0, fs-extra@^11.1.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
   integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
@@ -8042,6 +8077,13 @@ json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
+json-schema-ref-parser@^9.0.9:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz#66ea538e7450b12af342fa3d5b8458bc1e1e013f"
+  integrity sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "9.0.9"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
@@ -8930,6 +8972,17 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+openapi-typescript-codegen@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-codegen/-/openapi-typescript-codegen-0.25.0.tgz#0cb028f54b33b0a63bd9da3756c1c41b4e1a70e2"
+  integrity sha512-nN/TnIcGbP58qYgwEEy5FrAAjePcYgfMaCe3tsmYyTgI3v4RR9v8os14L+LEWDvV50+CmqiyTzRkKKtJeb6Ybg==
+  dependencies:
+    camelcase "^6.3.0"
+    commander "^11.0.0"
+    fs-extra "^11.1.1"
+    handlebars "^4.7.7"
+    json-schema-ref-parser "^9.0.9"
 
 optionator@^0.9.3:
   version "0.9.3"


### PR DESCRIPTION
This is just a draft PR to demonstrate a simple use of the codegen. Here I'm demonstrating the use for the `GET /auth/login` endpoint.

Nice things:
- You can see that codegen outputs client services based on the tags given to each path operation, probably a good habit to get into anyway for the OpenAPI spec.
- By adding proper type information to the path operation function, the frontend gets perfect typing for free from the codegen - this has actually already resolved an unspecified type in one of these example uses. It also encourages strong typing on the API, another good habit to get into.
- By using codegen for the frontend client, we no longer need the manually defined fetcher for this endpoint.
- The codegen can output its clients backed by axios requests which we're already using, I've set the package.json script and new VSCode task to do so.

Ugly things:
- You can see that I'm setting the `OpenAPI.BASE` to be our API's base URI in `_app.tsx`. This feels kind of hacky to me, but works and seems to be the recommended approach.
- The function names for each path operation are currently a little verbose (e.g. `getLoginKindsAuthLoginGet`). It's because they're taken from the operation IDs in the OpenAPI spec. We can change how those are generated in the backend quite easily (to be only the function name for example), but they need to be unique across all paths so there's a trade off there of shifting responsibility on to the developer.

Would close #2083 