### PR TITLE
fix(size): replaced SI prefixes with IEC prefixes

### DIFF
--- a/frontend/src/size.ts
+++ b/frontend/src/size.ts
@@ -1,9 +1,31 @@
+function roundNumber(number: number, digits: number) {
+  const multiple = Math.pow(10, digits)
+  return Math.floor(number * multiple + 0.50000000000001) / multiple
+}
+
 export function calculateHumanReadableSize(size: number) {
-  if (size > 1_000_000_000) {
-    return (size / 1_000_000_000).toFixed(2) + " GB"
-  } else if (size > 1_000_000) {
-    return Math.round(size / 1_000_000) + " MB"
-  } else {
-    return Math.round(size / 1_000) + " KB"
+  // (Maximum) number of digits to round to after floating point.
+  const ROUND_DIGITS = 2
+
+  // First letters of multiples of 2, more precisely of 2^10.
+  const UNIT_LETTERS = ["B", "K", "M", "G", "T", "P", "E", "Z", "Y"]
+
+  const i = "i" // From "binary".
+  const POW10 = 1024 // 2 to the power of 10.
+
+  if (size < POW10) {
+    // Explicit whitespace for good measures.
+    return `${size}` + " " + `${UNIT_LETTERS[0]}`
   }
+  let pow10Count = 0 // Shows which multiple of 2^10 the `value` is (i.e., 2^10^0).
+  let value = size
+  while (value >= POW10 && pow10Count < UNIT_LETTERS.length - 1) {
+    value /= POW10
+    pow10Count++
+  }
+  return (
+    `${roundNumber(value, ROUND_DIGITS)}` +
+    " " +
+    `${UNIT_LETTERS[pow10Count]}${i}${UNIT_LETTERS[0]}`
+  )
 }

--- a/frontend/src/size.ts
+++ b/frontend/src/size.ts
@@ -1,31 +1,23 @@
-function roundNumber(number: number, digits: number) {
-  const multiple = Math.pow(10, digits)
-  return Math.floor(number * multiple + 0.50000000000001) / multiple
-}
-
 export function calculateHumanReadableSize(size: number) {
-  // (Maximum) number of digits to round to after floating point.
-  const ROUND_DIGITS = 2
-
   // First letters of multiples of 2, more precisely of 2^10.
-  const UNIT_LETTERS = ["B", "K", "M", "G", "T", "P", "E", "Z", "Y"]
-
+  const UNIT_CHARS = ["B", "K", "M", "G", "T", "P", "E", "Z", "Y"]
   const i = "i" // From "binary".
-  const POW10 = 1024 // 2 to the power of 10.
-
+  const POW10 = 1024 // 2^10
   if (size < POW10) {
-    // Explicit whitespace for good measures.
-    return `${size}` + " " + `${UNIT_LETTERS[0]}`
+    return size.toString() + " " + UNIT_CHARS[0].toString()
   }
-  let pow10Count = 0 // Shows which multiple of 2^10 the `value` is (i.e., 2^10^0).
+  // Shows which multiple of 2^10 the `value` is (i.e., 2^10^0).
+  let pow10Count = 0
   let value = size
-  while (value >= POW10 && pow10Count < UNIT_LETTERS.length - 1) {
+  while (value >= POW10 && pow10Count < UNIT_CHARS.length - 1) {
     value /= POW10
     pow10Count++
   }
   return (
-    `${roundNumber(value, ROUND_DIGITS)}` +
+    // .toFixed() will round to fixed number of digits,
+    // parseFloat() will convert strings like 1.00 to 1 and 1.10 to 1.1.
+    parseFloat(value.toFixed(2)).toString() +
     " " +
-    `${UNIT_LETTERS[pow10Count]}${i}${UNIT_LETTERS[0]}`
+    `${UNIT_CHARS[pow10Count]}${i}${UNIT_CHARS[0]}`
   )
 }

--- a/frontend/src/size.ts
+++ b/frontend/src/size.ts
@@ -6,13 +6,12 @@ export function calculateHumanReadableSize(size: number) {
   if (size < POW10) {
     return size.toString() + " " + UNIT_CHARS[0].toString()
   }
-  // Shows which multiple of 2^10 the `value` is (i.e., 2^10^0).
-  let pow10Count = 0
-  let value = size
-  while (value >= POW10 && pow10Count < UNIT_CHARS.length - 1) {
-    value /= POW10
-    pow10Count++
-  }
+  // Shows which multiple of 2^10 the `size` is (i.e., 2^10^0).
+  const pow10Count = Math.min(
+    Math.floor(Math.log(size) / Math.log(POW10)),
+    UNIT_CHARS.length - 1,
+  )
+  const value = size / Math.pow(POW10, pow10Count)
   return (
     // .toFixed() will round to fixed number of digits,
     // parseFloat() will convert strings like 1.00 to 1 and 1.10 to 1.1.


### PR DESCRIPTION
I tidied up the code (from the first commit). Things to note:
- added explicit whitespace (`" "`) in string concatenation
- added explicit const for `"i"` for use in string concatenation
- added alias for 1024 (because it's used several times)
- if only 1 value is converted to string, then used more readable `.toString()` in string concatenation
- the function runs in O(1) using log with base 1024 to get the power, but not more than `UNIT_CHARS.length - 1` (because YiB is the last unit which is `2^10^8`)
- I think I followed all the styling conventions from this project (I also used `prettier`)

Closes #2139.
