### PR TITLE
Fix create permission text

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -479,7 +479,6 @@
   "full-file-system-read-write-access": "Full file system read/write access",
   "can-read-write-home-folder": "Can read and write all data in your home folder",
   "can-read-write-all-data": "Can read and write all data in the directory",
-  "can-create-files": "Can create files in the directory",
   "download-folder-read-write-access": "Download folder read/write access",
   "download-folder-read-access": "Download folder read access",
   "can-read-all-data-in-your-download-folder": "Can read all data in your downloads folder",

--- a/frontend/src/safety.ts
+++ b/frontend/src/safety.ts
@@ -603,7 +603,7 @@ function readWriteTranslationKey(filesystemPermission: string): string {
   } else if (isReadWrite(filesystemPermission)) {
     return "can-read-write-all-data"
   } else if (isCreate(filesystemPermission)) {
-    return "can-create-files"
+    return "can-read-write-all-data"
   } else {
     return "can-read-write-all-data"
   }


### PR DESCRIPTION
As mentioned in https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html :create also means that read and write are allowed. We omit the create part for now, as gnome-software does the same.