### PR TITLE
Send held and approved/rejected emails to moderators too

### DIFF
--- a/backend/app/emails.py
+++ b/backend/app/emails.py
@@ -44,6 +44,8 @@ class EmailInfo(BaseModel):
     category: EmailCategory
     subject: str
     template_data: dict[str, Any]
+    # Only works when app_id is set and email is not user specific
+    inform_moderators: bool = False
 
 
 def _create_html(info: EmailInfo, app_name: str, email: str, user_display_name: str):
@@ -129,6 +131,13 @@ def send_email(info: EmailInfo, db):
                 db, direct_upload_app
             )
             for _dev, user in by_direct_upload:
+                messages.append(_create_message(user, info, db))
+
+        if info.inform_moderators:
+            moderators = db.session.query(models.FlathubUser).filter_by(
+                is_moderator=True
+            )
+            for user in moderators:
                 messages.append(_create_message(user, info, db))
 
     if info.user_id is not None:

--- a/backend/app/moderation.py
+++ b/backend/app/moderation.py
@@ -332,6 +332,7 @@ def submit_review_request(
                     EmailInfo(
                         user_id=None,
                         app_id=app_id,
+                        inform_moderators=True,
                         category=EmailCategory.MODERATION_HELD,
                         subject=f"Build #{review_request.build_id} held for review",
                         template_data={
@@ -413,6 +414,7 @@ def submit_review(
         EmailInfo(
             user_id=None,
             app_id=request.appid,
+            inform_moderators=True,
             category=EmailCategory.MODERATION_APPROVED
             if request.is_approved
             else EmailCategory.MODERATION_REJECTED,


### PR DESCRIPTION
@barthalion 

This should email us when something get's held for review and approved/rejected

I haven't runtime tested it, just implemented